### PR TITLE
Refactor xr rm poly

### DIFF
--- a/climpred/tests/test_stats.py
+++ b/climpred/tests/test_stats.py
@@ -1,0 +1,38 @@
+import pytest
+import numpy as np
+import xarray as xr
+
+from climpred.stats import xr_rm_trend
+
+
+def test_xr_rm_trend_2d_dataarray():
+    da = xr.DataArray(
+        np.vstack([np.arange(0, 5, 1),
+                   np.arange(0, 10, 2),
+                   np.arange(0, 40, 8),
+                   np.arange(0, 20, 4)]),
+        dims=['row', 'col']
+    )
+    da_dt = xr_rm_trend(da)
+    assert da_dt.shape == (4, 5)
+    # should have all values equal to 0 after detrending because it's linear
+    assert (xr_rm_trend(da, 'col') == 0).sum() == 20
+
+
+def test_xr_rm_trend_3d_dataset():
+    ds = xr.tutorial.open_dataset('air_temperature')
+    ds = ds.assign(**{'airx2': ds['air'] * 2})
+    ds_dt = xr_rm_trend(ds)
+
+    assert ds_dt['air'].shape == (2920, 25, 53)
+    assert ds_dt['airx2'].shape == (2920, 25, 53)
+
+
+def test_xr_rm_trend_3d_dataset_dim_order():
+    ds = xr.tutorial.open_dataset('air_temperature')
+    ds = ds.assign(**{'airx2': ds['air'] * 2})
+    ds = ds.transpose('lon', 'time', 'lat')
+    ds_dt = xr_rm_trend(ds)
+
+    assert list(ds_dt['air'].dims) == ['lon', 'time', 'lat']
+    assert list(ds_dt['airx2'].dims) == ['lon', 'time', 'lat']

--- a/climpred/tests/test_stats.py
+++ b/climpred/tests/test_stats.py
@@ -5,34 +5,85 @@ import xarray as xr
 from climpred.stats import xr_rm_trend
 
 
-def test_xr_rm_trend_2d_dataarray():
+@pytest.fixture
+def two_dim_da():
     da = xr.DataArray(
-        np.vstack([np.arange(0, 5, 1),
-                   np.arange(0, 10, 2),
-                   np.arange(0, 40, 8),
-                   np.arange(0, 20, 4)]),
+        np.vstack([np.arange(0, 5, 1.),
+                   np.arange(0, 10, 2.),
+                   np.arange(0, 40, 8.),
+                   np.arange(0, 20, 4.)]),
         dims=['row', 'col']
     )
-    da_dt = xr_rm_trend(da)
-    assert da_dt.shape == (4, 5)
-    # should have all values equal to 0 after detrending because it's linear
-    assert (xr_rm_trend(da, 'col') == 0).sum() == 20
+    return da
 
 
-def test_xr_rm_trend_3d_dataset():
+@pytest.fixture
+def multi_dim_ds():
     ds = xr.tutorial.open_dataset('air_temperature')
     ds = ds.assign(**{'airx2': ds['air'] * 2})
-    ds_dt = xr_rm_trend(ds)
-
-    assert ds_dt['air'].shape == (2920, 25, 53)
-    assert ds_dt['airx2'].shape == (2920, 25, 53)
+    return ds
 
 
-def test_xr_rm_trend_3d_dataset_dim_order():
-    ds = xr.tutorial.open_dataset('air_temperature')
-    ds = ds.assign(**{'airx2': ds['air'] * 2})
-    ds = ds.transpose('lon', 'time', 'lat')
-    ds_dt = xr_rm_trend(ds)
+def test_xr_rm_trend_missing_dim():
+    with pytest.raises(KeyError) as excinfo:
+        xr_rm_trend(xr.DataArray([0, 1, 2]), dim='non_existent')
+        assert "Input dim, 'non_existent'" in excinfo.value.message
 
-    assert list(ds_dt['air'].dims) == ['lon', 'time', 'lat']
-    assert list(ds_dt['airx2'].dims) == ['lon', 'time', 'lat']
+
+def test_xr_rm_trend_1d_dataarray(two_dim_da):
+    one_dim_da = two_dim_da.isel(row=0)
+    one_dim_da_dt = xr_rm_trend(one_dim_da, 'col')
+
+    assert one_dim_da_dt.shape == (5,)
+    # should have all values near 0 after detrending because it's linear
+    # but because of floating point precision, may not be 0
+    assert (one_dim_da_dt <= 1e-5).sum() == 5
+
+
+def test_xr_rm_trend_1d_dataarray_interp_nan(two_dim_da):
+    one_dim_da = two_dim_da.isel(row=0)
+    one_dim_da[:3] = np.nan
+    one_dim_da_dt = xr_rm_trend(one_dim_da, 'col')
+
+    assert one_dim_da_dt.shape == (5,)
+    assert np.isnan(one_dim_da_dt[:3]).all()  # should be replaced with nan
+    # since it's bfill, the linear trend no longer holds
+    assert (one_dim_da_dt <= 1e-5).sum() <= 20
+
+
+def test_xr_rm_trend_2d_dataarray(two_dim_da):
+    two_dim_da_dt = xr_rm_trend(two_dim_da, 'col')
+
+    assert two_dim_da_dt.shape == (4, 5)
+    # should have all values near 0 after detrending because it's linear
+    # but because of floating point precision, may not be 0
+    assert (two_dim_da_dt <= 1e-5).sum() == 20
+
+
+def test_xr_rm_trend_2d_dataarray_interp_nan(two_dim_da):
+    two_dim_da[2, :] = np.nan
+    two_dim_da_dt = xr_rm_trend(two_dim_da, 'col')
+
+    assert two_dim_da_dt.shape == (4, 5)
+    # should have 15 values (5 NaNs) near 0 after detrending because it's linear
+    # but because of floating point precision, may not be 0
+    assert (two_dim_da_dt <= 1e-5).sum() == 15
+    assert np.isnan(two_dim_da_dt[2]).all()  # should be replaced with nan
+
+def test_xr_rm_trend_3d_dataset(multi_dim_ds):
+    multi_dim_ds_dt = xr_rm_trend(multi_dim_ds)
+
+    # originally values were ~270 K, after detrending between -50 and 50
+    assert multi_dim_ds_dt['air'].shape == (2920, 25, 53)
+    assert multi_dim_ds_dt['airx2'].shape == (2920, 25, 53)
+    assert float(multi_dim_ds_dt['air'].min()) > -50
+    assert float(multi_dim_ds_dt['air'].max()) < 50
+
+
+def test_xr_rm_trend_3d_dataset_dim_order(multi_dim_ds):
+    multi_dim_ds = multi_dim_ds.transpose('lon', 'time', 'lat')
+    multi_dim_ds_dt = xr_rm_trend(multi_dim_ds)
+
+    # ensure the dims are back in its original state
+    assert list(multi_dim_ds_dt['air'].dims) == ['lon', 'time', 'lat']
+    assert list(multi_dim_ds_dt['airx2'].dims) == ['lon', 'time', 'lat']


### PR DESCRIPTION
# Description
Now handles xr.Dataset for xr_rm_poly and better exception message if dim doesn't exist
https://github.com/bradyrx/climpred/issues/91
https://github.com/bradyrx/climpred/issues/93

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x  ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added tests/test_stats.py

Saved the values before refactoring, and compared with the values after refactor from DPLE_hindcast_prediction notebook:
![image](https://user-images.githubusercontent.com/15331990/56783011-75c74c80-679e-11e9-848a-31ff8a701747.png)

Also tried performing on multi-dim Dataset and xr.DataArray

```
import xarray as xr
import climpred as cp

ds = xr.tutorial.open_dataset('air_temperature')
ds = ds.assign(**{'airx2': ds['air'] * 2})

cp.stats.xr_rm_trend(ds['air'])
cp.stats.xr_rm_trend(ds)
```
![image](https://user-images.githubusercontent.com/15331990/56783074-b757f780-679e-11e9-8885-80fe82e7a8fa.png)


# Checklist:

- [ ] All notebooks run with this branch installed. (Notebooks can be updated to reflect changes)
- [x] Tests added for `pytest` if necessary.
- [x] `pytest` runs without breaking.
- [n/a ] I have added docstrings to all new functions.
- [n/a] I have updated the wiki with documentation, if necessary.
- [x] I have commented my code, particularly in hard-to-understand areas
