### PR TITLE
Add DimensionError and CoordinateError

### DIFF
--- a/climpred/exceptions.py
+++ b/climpred/exceptions.py
@@ -1,0 +1,17 @@
+class Error(Exception):
+    """Base class for custom exceptions in climpred."""
+    pass
+
+
+class DimensionError(Error):
+    """Exception raised when the input xarray object doesn't have the
+    appropriate dimensions."""
+    def __init__(self, message):
+        self.message = message
+
+
+class CoordinateError(Error):
+    """Exception raised when the input xarray object doesn't have the
+    appropriate coordinates."""
+    def __init__(self, message):
+        self.message = message


### PR DESCRIPTION
# Description

Adds a custom exceptions submodule to begin to address https://github.com/bradyrx/climpred/issues/111. This can make error reporting more clear. In a lot of cases we'll raise an error if we don't have the expected dimensions/coordinates in the input xarray object, but use things like `ValueError` which don't exactly make sense.

Fixes # https://github.com/bradyrx/climpred/issues/111

## Usage

In a given module:

```python
from .exceptions import *

def dummy_function(hind):
    if 'member' not in hind.dims:
        raise DimensionError("Please supply a hindcast product with a 'member' dimension")
```

Example of what comes out in a program:
```python
import numpy as np
import xarray as xr
from climpred.test import dummy_function

data = np.random.rand(100, 100)
ds = xr.DataArray(data, dims=['lat', 'lon'])
dummy_function(ds)
```

```python-traceback
---------------------------------------------------------------------------
DimensionError                            Traceback (most recent call last)
<ipython-input-6-63df43832b62> in <module>
----> 1 cp.test.dummy_function(ds)

~/miniconda3/envs/python3/lib/python3.7/site-packages/climpred/test.py in dummy_function(hind)
      4 def dummy_function(hind):
      5     if 'member' not in hind.dims:
----> 6         raise DimensionError("Please supply a hindcast product with a 'member' dimension")

DimensionError: Please supply a hindcast product with a 'member' dimension
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


