### PR TITLE
Fix help() for decorated functions

### DIFF
--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -1,5 +1,3 @@
-import sys
-import traceback
 from functools import wraps
 
 import xarray as xr

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -1,3 +1,7 @@
+import sys
+import traceback
+from functools import wraps
+
 import xarray as xr
 
 
@@ -19,26 +23,34 @@ def check_xarray(func, *dec_args):
     Decorate a function to ensure the first arg being submitted is
     either a Dataset or DataArray.
     """
+    @wraps(func)
     def wrapper(*args, **kwargs):
-        ds_da_locs = dec_args[0]
-        if not isinstance(ds_da_locs, list):
-            ds_da_locs = [ds_da_locs]
+        try:
+            ds_da_locs = dec_args[0]
+            if not isinstance(ds_da_locs, list):
+                ds_da_locs = [ds_da_locs]
 
-        for loc in ds_da_locs:
-            if isinstance(loc, int):
-                ds_da = args[loc]
-            elif isinstance(loc, str):
-                ds_da = kwargs[loc]
+            for loc in ds_da_locs:
+                if isinstance(loc, int):
+                    ds_da = args[loc]
+                elif isinstance(loc, str):
+                    ds_da = kwargs[loc]
 
-            is_ds_da = isinstance(ds_da, (xr.Dataset, xr.DataArray))
-            if not is_ds_da:
-                typecheck = type(ds_da)
-                raise IOError(f"""The input data is not an xarray DataArray or
-                    Dataset. climpred is built to wrap xarray to make
-                    use of its awesome features. Please input an xarray object
-                    and retry the function.
-                    Your input was of type: {typecheck}""")
+                is_ds_da = isinstance(ds_da, (xr.Dataset, xr.DataArray))
+                if not is_ds_da:
+                    typecheck = type(ds_da)
+                    raise IOError(
+                        f"""The input data is not an xarray DataArray or
+                        Dataset. climpred is built to wrap xarray to make
+                        use of its awesome features. Please input an xarray
+                        object and retry the function.
 
+                        Your input was of type: {typecheck}""")
+        except Exception:
+            pass
+        # this is outside of the try/except so that the traceback is relevant
+        # to the actual function call rather than showing a simple Exception
+        # (probably IndexError from trying to subselect an empty dec_args list)
         return func(*args, **kwargs)
     return wrapper
 

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -46,7 +46,7 @@ def check_xarray(func, *dec_args):
                         object and retry the function.
 
                         Your input was of type: {typecheck}""")
-        except Exception:
+        except IndexError:
             pass
         # this is outside of the try/except so that the traceback is relevant
         # to the actual function call rather than showing a simple Exception


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes https://github.com/bradyrx/climpred/issues/146

## Type of change

Please delete options that are not relevant.

-   [  x ]  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
`import climpred as cp`
`help(cp.stats.autocorr)`

```
Help on function autocorr in module climpred.stats:

autocorr(ds, lag=1, dim='time', return_p=False)
    Calculate the lagged correlation of time series.

    Args:
        ds (xarray object): Time series or grid of time series.
        lag (optional int): Number of time steps to lag correlate to.
        dim (optional str): Name of dimension to autocorrelate over.
        return_p (optional bool): If True, return correlation coefficients
                                  and p values.

    Returns:
        Pearson correlation coefficients.

        If return_p, also returns their associated p values.

```

## Checklist (while developing)
-   [ x ]  I have commented my code, particularly in hard-to-understand areas
