### PR TITLE
test coveralls as test coverage

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: M6KWeBXmDYgetbGH1OMSF5fUj85tRIegc

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,13 @@ install:
   - pip install .['graphics']
   - python setup.py install --user
   - pip install treon
-  - pip install codecov
   - pip install pytest-cov
+  - pip install coveralls
 
 script:
   - treon notebooks
-  - export CODECOV_TOKEN="884f8514-9e87-4fdc-81f0-ab8e6463e99e"
-  - pytest --cov=./ climpred/tests/
-  - codecov
+  - coverage run --source climpred -m py.test
+  - coverage report
 
+after_success:
+  - coveralls    

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ An xarray wrapper for analysis of ensemble forecast models for climate predictio
 
 [![Build Status](https://travis-ci.org/bradyrx/climpred.svg?branch=master)](https://travis-ci.org/bradyrx/climpred)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a532752e9e814c6e895694463f307cd9)](https://www.codacy.com/app/bradyrx/climpred?utm_source=github.com&utm_medium=referral&utm_content=bradyrx/climpred&utm_campaign=Badge_Grade)
-[![codecov](https://codecov.io/gh/bradyrx/climpred/branch/master/graph/badge.svg)](https://codecov.io/gh/bradyrx/climpred)
+[![Coverage Status](https://coveralls.io/repos/github/bradyrx/climpred/badge.svg?branch=master)](https://coveralls.io/github/bradyrx/climpred?branch=master)
+
 
 ## Release
 


### PR DESCRIPTION
# Description

Another attempt at installing a test coverage utility. Tested on my laptop locally and this one seems to work (https://coveralls.io/builds/23662285). Ran once, then added a simple test for `corr` from stats and it reflected that change, so this looks promising.

If this works, will  add a coveralls badge instead and remove codecov.