### PR TITLE
Improve checks exception msgs

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: M6KWeBXmDYgetbGH1OMSF5fUj85tRIegc

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,13 @@ install:
   - pip install .['graphics']
   - python setup.py install --user
   - pip install treon
-  - pip install codecov
   - pip install pytest-cov
+  - pip install coveralls
 
 script:
   - treon notebooks
-  - export CODECOV_TOKEN="884f8514-9e87-4fdc-81f0-ab8e6463e99e"
-  - pytest --cov=./ climpred/tests/
-  - codecov
+  - coverage run --source climpred -m py.test
+  - coverage report
 
+after_success:
+  - coveralls    

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ An xarray wrapper for analysis of ensemble forecast models for climate predictio
 
 [![Build Status](https://travis-ci.org/bradyrx/climpred.svg?branch=master)](https://travis-ci.org/bradyrx/climpred)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a532752e9e814c6e895694463f307cd9)](https://www.codacy.com/app/bradyrx/climpred?utm_source=github.com&utm_medium=referral&utm_content=bradyrx/climpred&utm_campaign=Badge_Grade)
-[![codecov](https://codecov.io/gh/bradyrx/climpred/branch/master/graph/badge.svg)](https://codecov.io/gh/bradyrx/climpred)
+[![Coverage Status](https://coveralls.io/repos/github/bradyrx/climpred/badge.svg?branch=master)](https://coveralls.io/github/bradyrx/climpred?branch=master)
+
 
 ## Release
 

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -34,14 +34,15 @@ from .exceptions import (DimensionError, DatasetError, VariableError)
 def _check_prediction_ensemble_dimensions(xobj):
     """
     Checks that at the minimum, the climate prediction  object has dimensions
-    `init` and `lead` (i.e., it's a time series with lead
-    times.
+    `init` and `lead` (i.e., it's a time series with lead times.
     """
     cond = all(dims in xobj.dims for dims in ['init', 'lead'])
     if not cond:
         # create custom error here.
-        raise DimensionError("""Your decadal prediction object must contain the
-            dimensions `lead` and `init` at the minimum.""")
+        raise DimensionError(
+            'Your prediction object must contain the '
+            'dimensions `lead` and `init` at the minimum.'
+        )
 
 
 def _check_reference_dimensions(init, ref):
@@ -56,8 +57,11 @@ def _check_reference_dimensions(init, ref):
     if 'member' in init_dims:
         init_dims.remove('member')
     if not (set(ref.dims) == set(init_dims)):
-        raise DimensionError("""Dimensions must match initialized
-            prediction ensemble dimensions (excluding `lead` and `member`.)""")
+        unmatch_dims = set(ref.dims) ^ set(init_dims)
+        raise DimensionError(
+            'Dimensions must match initialized prediction ensemble '
+            f'dimensions; these dimensions do not match: {unmatch_dims}.'
+        )
 
 
 def _check_reference_vars_match_initialized(init, ref):
@@ -68,13 +72,15 @@ def _check_reference_vars_match_initialized(init, ref):
     ref: new addition
     init: dp.initialized
     """
-    init_list = [var for var in init.data_vars]
-    ref_list = [var for var in ref.data_vars]
+    init_vars = list(init.data_vars)
+    ref_vars = list(ref.data_vars)
     # https://stackoverflow.com/questions/10668282/
     # one-liner-to-check-if-at-least-one-item-in-list-exists-in-another-list
-    if set(init_list).isdisjoint(ref_list):
-        raise VariableError("""Please provide a Dataset/DataArray with at least
-        one matching variable to the initialized prediction ensemble.""")
+    if set(init_vars).isdisjoint(ref_vars):
+        raise VariableError(
+            'Please provide a Dataset/DataArray with at least '
+            'one matching variable to the initialized prediction ensemble; '
+            f'got {init_vars} for init and {ref_vars} for ref.')
 
 
 # ----------

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -1,5 +1,3 @@
-import sys
-import traceback
 from functools import wraps
 
 import xarray as xr

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -1,3 +1,7 @@
+import sys
+import traceback
+from functools import wraps
+
 import xarray as xr
 
 
@@ -19,26 +23,34 @@ def check_xarray(func, *dec_args):
     Decorate a function to ensure the first arg being submitted is
     either a Dataset or DataArray.
     """
+    @wraps(func)
     def wrapper(*args, **kwargs):
-        ds_da_locs = dec_args[0]
-        if not isinstance(ds_da_locs, list):
-            ds_da_locs = [ds_da_locs]
+        try:
+            ds_da_locs = dec_args[0]
+            if not isinstance(ds_da_locs, list):
+                ds_da_locs = [ds_da_locs]
 
-        for loc in ds_da_locs:
-            if isinstance(loc, int):
-                ds_da = args[loc]
-            elif isinstance(loc, str):
-                ds_da = kwargs[loc]
+            for loc in ds_da_locs:
+                if isinstance(loc, int):
+                    ds_da = args[loc]
+                elif isinstance(loc, str):
+                    ds_da = kwargs[loc]
 
-            is_ds_da = isinstance(ds_da, (xr.Dataset, xr.DataArray))
-            if not is_ds_da:
-                typecheck = type(ds_da)
-                raise IOError(f"""The input data is not an xarray DataArray or
-                    Dataset. climpred is built to wrap xarray to make
-                    use of its awesome features. Please input an xarray object
-                    and retry the function.
-                    Your input was of type: {typecheck}""")
+                is_ds_da = isinstance(ds_da, (xr.Dataset, xr.DataArray))
+                if not is_ds_da:
+                    typecheck = type(ds_da)
+                    raise IOError(
+                        f"""The input data is not an xarray DataArray or
+                        Dataset. climpred is built to wrap xarray to make
+                        use of its awesome features. Please input an xarray
+                        object and retry the function.
 
+                        Your input was of type: {typecheck}""")
+        except Exception:
+            pass
+        # this is outside of the try/except so that the traceback is relevant
+        # to the actual function call rather than showing a simple Exception
+        # (probably IndexError from trying to subselect an empty dec_args list)
         return func(*args, **kwargs)
     return wrapper
 

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -46,7 +46,7 @@ def check_xarray(func, *dec_args):
                         object and retry the function.
 
                         Your input was of type: {typecheck}""")
-        except Exception:
+        except IndexError:
             pass
         # this is outside of the try/except so that the traceback is relevant
         # to the actual function call rather than showing a simple Exception


### PR DESCRIPTION
Improve exception msgs for various checks.

I use 'Some string' rather than """Some string""" because """ keeps the indentation and it's ugly to me in warning messages.

![image](https://user-images.githubusercontent.com/15331990/58606620-2074d400-8251-11e9-90dc-7526be414840.png)

https://github.com/bradyrx/climpred/issues/150

## Type of change
- [x] Aesthetics

# How Has This Been Tested?
![image](https://user-images.githubusercontent.com/15331990/58606686-6762c980-8251-11e9-939b-1143ad2d8a76.png)
