### PR TITLE
Remove predictability horizon for v1

### DIFF
--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -674,12 +674,3 @@ class HindcastEnsemble(PredictionEnsemble):
                     self.initialized, self.reference[key], metric=metric
                 )
             return persistence
-
-    def compute_horizon(self, refname=None):
-        """
-        Method to compute the predictability horizon.
-        """
-        raise NotImplementedError(
-            """Predictability horizons are not yet fully
-            implemented and tested."""
-        )


### PR DESCRIPTION
# Description

Deletes the predictability horizon function from `climpred` for the v1 release. We discussed that it would be better to formalize for v2.

Fixes https://github.com/bradyrx/climpred/issues/159