### PR TITLE
add support for monthly-resolution predictions

### DIFF
--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -87,9 +87,29 @@ def compute_perfect_model(ds, control, metric='rmse', comparison='m2e'):
     return res
 
 
-def _slice_to_correct_time(forecast, reference, nlags=None):
+def _slice_to_correct_time(forecast, reference, resolution='Y', nlags=None):
     """Reduces the forecast and reference object to a compatable window of time based
-    on their minimum and maximum times and how many lags are being computed."""
+    on their minimum and maximum times and how many lags are being computed.
+
+    Args:
+        forecast (xarray object):
+            Prediction ensemble
+        reference (xarray object):
+            Reference to compare predictions to
+        resolution (str):
+            Temporal resolution of the predictions
+            'Y': annual
+            'M': monthly
+        nlags (int):
+            Number of lags being computed for the forecast
+
+    Returns:
+        Post-processed forecast and reference, trimmed to the appropriate time lengths.
+    """
+    if resolution not in ['Y', 'M']:
+        raise ValueError(
+            f"Your resolution of {resolution} is not 'Y' (annual) or 'M' (monthly)."
+        )
     if nlags is None:
         nlags = forecast.lead.size
     # take only inits for which we have references at all leahind


### PR DESCRIPTION
# Description

This PR adds support for prediction ensembles at monthly resolution.

Fixes https://github.com/bradyrx/climpred/issues/44

## Type of change

Please delete options that are not relevant.

-   [ ]  New feature (non-breaking change which adds functionality)
-   [ ]  This change requires a documentation update

# How Has This Been Tested?

```python
# Load in global average SST for monthly DPLE 
hind = xr.open_dataset('/glade/u/home/rbrady/scratch/monthly_SST_global_avg.nc')
hind = hind.rename({'anom': 'SST'})
print(hind)
>>> <xarray.Dataset>
>>> Dimensions:  (init: 62, lead: 122)
>>> Coordinates:
>>>   * init     (init) int32 1955 1956 1957 1958 1959 ... 2012 2013 2014 2015 2016
>>>   * lead     (lead) int32 1 2 3 4 5 6 7 8 9 ... 115 116 117 118 119 120 121 122
>>>     member   int32 ...
>>> Data variables:
>>>     SST      (init, lead) float32 ...

reference = xr.open_dataset('/glade/u/home/rbrady/scratch/FOSI_global_SST.nc')
# Convert FOSI to anomalies
reference = reference - reference.sel(time=slice('1964', '2014')).mean('time')
reference = reference.groupby('time.month') - reference.groupby('time.month').mean('time')

>>>  <xarray.Dataset>
>>>  Dimensions:  (time: 840)
>>>  Coordinates:
>>>      z_t      float32 500.0
>>>    * time     (time) datetime64[ns] 1948-01-01 1948-02-01 ... 2017-12-01
>>>      month    (time) int64 1 2 3 4 5 6 7 8 9 10 11 ... 2 3 4 5 6 7 8 9 10 11 12
>>>  Data variables:
>>>      SST      (time) float32 0.099155456 0.042655587 ... 0.29147333 0.17652681

# Add actual initialization dates to DPLE. November initializations.
hind['init'] = np.arange('1954-11', '2016-11', dtype='datetime64[M]')[::12]
reference['time'] = np.arange('1948-01', '2018-01', dtype='datetime64[M]')

# Subtract one from hindcast lead. The first timestep is actually the November comparison, 
# since initialization was November 1 and we're looking at the full month of November.
hind['lead'] = hind['lead'] - 1
cp.prediction.compute_hindcast(hind, reference, resolution='M').SST.plot()
```

<img width="397" alt="Screen Shot 2019-06-07 at 1 51 40 PM" src="https://user-images.githubusercontent.com/8881170/59129929-63a70500-892b-11e9-9e28-420bb06d5336.png">


## Checklist (while developing)

-   [ ]  I have added docstrings to all new functions.
-   [ ]  I have commented my code, particularly in hard-to-understand areas
-   [ ]  Tests added for `pytest`, if necessary.

## Pre-Merge Checklist (final steps)

-   [ ]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.
-   [ ]  All notebooks run with this branch; tested via `treon`.
-   [ ]  `pytest` runs without breaking.

## Todo

- [ ] Add testing for monthly resolution
- [ ] Add temporal resolution to `classes`
- [ ] Check functions outside of `compute_hindcast`
- [ ] Add `datetime` module?