### PR TITLE
don't allow anyone to push to master directly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,14 @@ repos:
   -   repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v2.2.3
       hooks:
-      -   id: trailing-whitespace
-      -   id: end-of-file-fixer
-      -   id: check-docstring-first
-      -   id: check-yaml
-      -   id: double-quote-string-fixer
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-docstring-first
+      - id: check-yaml
+      - id: double-quote-string-fixer
+      - id: no-commit-to-branch
+      - id: debug-statements
+      - id: check-merge-conflict
 
   -   repo: https://github.com/ambv/black
       rev: 19.3b0
@@ -24,4 +27,4 @@ repos:
   -   repo: https://github.com/asottile/blacken-docs
       rev: v1.0.0
       hooks:
-      -   id: blacken-docs
+      - id: blacken-docs


### PR DESCRIPTION
Adds hooks to disallow users (mainly collaborators and administrator) from pushing directly to master. Also checks that `pdb` and other debuggers aren't left in code. And that nobody is adding files with merge commits still lingering.