### PR TITLE
Update compute uninitialized 

### DIFF
--- a/climpred/tests/test_hindcast_prediction.py
+++ b/climpred/tests/test_hindcast_prediction.py
@@ -138,7 +138,11 @@ def test_uninitialized(uninitialized_da, reconstruction_da, metric, comparison):
     """
     res = (
         compute_uninitialized(
-            uninitialized_da, reconstruction_da, metric=metric, comparison=comparison
+            uninitialized_da,
+            reconstruction_da,
+            metric=metric,
+            comparison=comparison,
+            nlags=5,
         )
         .isnull()
         .any()


### PR DESCRIPTION
# Description

Now `compute_uninitialized` automatically reduces the uninitialized ensemble and reference to the same time frame for one lead year. It also gives the option to return for a set number of `nlags`.

Fixes https://github.com/bradyrx/climpred/issues/186

## Type of change

Please delete options that are not relevant.

-   [X]  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Small update to `pytest` to include the `nlags` argument. Simple test in notebook:

<img width="789" alt="Screen Shot 2019-07-02 at 9 37 43 PM" src="https://user-images.githubusercontent.com/8881170/60561682-aa610280-9d11-11e9-8912-7e4ff56eb1bf.png">

## Checklist (while developing)

-   [X]  I have added docstrings to all new functions.
-   [X]  I have commented my code, particularly in hard-to-understand areas
-   [X]  Tests added for `pytest`, if necessary.

## Pre-Merge Checklist (final steps)

-   [X]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [X]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.