### PR TITLE
Update compute persistence for time step prior to init

### DIFF
--- a/climpred/tests/test_hindcast_prediction.py
+++ b/climpred/tests/test_hindcast_prediction.py
@@ -138,7 +138,11 @@ def test_uninitialized(uninitialized_da, reconstruction_da, metric, comparison):
     """
     res = (
         compute_uninitialized(
-            uninitialized_da, reconstruction_da, metric=metric, comparison=comparison
+            uninitialized_da,
+            reconstruction_da,
+            metric=metric,
+            comparison=comparison,
+            nlags=5,
         )
         .isnull()
         .any()

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -73,6 +73,17 @@ def intersect(lst1, lst2):
     """
     Custom intersection, since `set.intersection()` changes type of list.
     """
+
+    def conv_xarray(lst):
+        # Quick conversion to array if xarray object comes in.
+        # This list comprehension can't handle xarray objects.
+        if isinstance(lst, xr.DataArray):
+            return lst.values
+        else:
+            return lst
+
+    lst1 = conv_xarray(lst1)
+    lst2 = conv_xarray(lst2)
     lst3 = [value for value in lst1 if value in lst2]
     return np.array(lst3)
 


### PR DESCRIPTION
# Description

This adjusts the `compute_persistence` function to attempt to compute persistence starting with the year prior to initialization (per personal communication with S. Yeager, also mentioned explicitly in Jacox et al. 2017). This will be more important for monthly forecasts, but should still be implemented here.

Fixes https://github.com/bradyrx/climpred/issues/190

## Type of change

Please delete options that are not relevant.

-   [X]  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Note that the warning message is kinda ugly due to `black` enforcing a style on the warning message**.

<img width="1042" alt="Screen Shot 2019-07-02 at 10 27 59 PM" src="https://user-images.githubusercontent.com/8881170/60563348-ac7a8f80-9d18-11e9-827e-196ba65835df.png">

## Checklist (while developing)

-   [X]  I have commented my code, particularly in hard-to-understand areas

## Pre-Merge Checklist (final steps)

-   [X]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [X]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

## References

1. Jacox, Michael G., et al. "On the skill of seasonal sea surface temperature forecasts in the California Current System and its connection to ENSO variability." Climate Dynamics (2017): 1-15.
