### PR TITLE
Print version feature

### DIFF
--- a/climpred/__init__.py
+++ b/climpred/__init__.py
@@ -1,3 +1,5 @@
+from pkg_resources import DistributionNotFound, get_distribution
+
 from . import (
     bootstrap,
     constants,
@@ -11,3 +13,10 @@ from . import (
     tutorial,
 )
 from .classes import HindcastEnsemble, PerfectModelEnsemble
+from .versioning.print_versions import show_versions
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    pass

--- a/climpred/versioning/print_versions.py
+++ b/climpred/versioning/print_versions.py
@@ -1,0 +1,154 @@
+'''utility functions for printing version information
+see pandas/pandas/util/_print_versions.py'''
+
+import codecs
+import importlib
+import locale
+import os
+import platform
+import struct
+import subprocess
+import sys
+
+
+def get_sys_info():
+    'Returns system information as a dict'
+
+    blob = []
+
+    # get full commit hash
+    commit = None
+    if os.path.isdir('.git') and os.path.isdir('xarray'):
+        try:
+            pipe = subprocess.Popen(
+                'git log --format="%H" -n 1'.split(' '),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            so, _ = pipe.communicate()
+        except Exception:
+            pass
+        else:
+            if pipe.returncode == 0:
+                commit = so
+                try:
+                    commit = so.decode('utf-8')
+                except ValueError:
+                    pass
+                commit = commit.strip().strip('"')
+
+    blob.append(('commit', commit))
+
+    try:
+        (sysname, _, release, _, machine, processor) = platform.uname()
+        blob.extend(
+            [
+                ('python', sys.version),
+                ('python-bits', struct.calcsize('P') * 8),
+                ('OS', '%s' % (sysname)),
+                ('OS-release', '%s' % (release)),
+                # ("Version", "%s" % (version)),
+                ('machine', '%s' % (machine)),
+                ('processor', '%s' % (processor)),
+                ('byteorder', '%s' % sys.byteorder),
+                ('LC_ALL', '%s' % os.environ.get('LC_ALL', 'None')),
+                ('LANG', '%s' % os.environ.get('LANG', 'None')),
+                ('LOCALE', '%s.%s' % locale.getlocale()),
+            ]
+        )
+    except Exception:
+        pass
+
+    return blob
+
+
+def show_versions(as_json=False):
+    sys_info = get_sys_info()
+
+    deps = [
+        # (MODULE_NAME, f(mod) -> mod version)
+        ('climpred', lambda mod: mod.__version__),
+        ('xarray', lambda mod: mod.__version__),
+        ('pandas', lambda mod: mod.__version__),
+        ('numpy', lambda mod: mod.__version__),
+        ('scipy', lambda mod: mod.__version__),
+        ('cftime', lambda mod: mod.__version__),
+        ('dask', lambda mod: mod.__version__),
+        ('distributed', lambda mod: mod.__version__),
+        # setup/test
+        ('setuptools', lambda mod: mod.__version__),
+        ('pip', lambda mod: mod.__version__),
+        ('conda', lambda mod: mod.__version__),
+        ('pytest', lambda mod: mod.__version__),
+        # Misc.
+        ('IPython', lambda mod: mod.__version__),
+        ('sphinx', lambda mod: mod.__version__),
+    ]
+
+    deps_blob = list()
+    for (modname, ver_f) in deps:
+        try:
+            if modname in sys.modules:
+                mod = sys.modules[modname]
+            else:
+                mod = importlib.import_module(modname)
+        except Exception:
+            deps_blob.append((modname, None))
+        else:
+            try:
+                ver = ver_f(mod)
+                deps_blob.append((modname, ver))
+            except Exception:
+                deps_blob.append((modname, 'installed'))
+
+    if as_json:
+        try:
+            import json
+        except Exception:
+            import simplejson as json
+
+        j = dict(system=dict(sys_info), dependencies=dict(deps_blob))
+
+        if as_json is True:
+            print(j)
+        else:
+            with codecs.open(as_json, 'wb', encoding='utf8') as f:
+                json.dump(j, f, indent=2)
+
+    else:
+
+        print('\nINSTALLED VERSIONS')
+        print('------------------')
+
+        for k, stat in sys_info:
+            print('%s: %s' % (k, stat))
+
+        print('')
+        for k, stat in deps_blob:
+            print('%s: %s' % (k, stat))
+
+
+def main():
+    from optparse import OptionParser
+
+    parser = OptionParser()
+    parser.add_option(
+        '-j',
+        '--json',
+        metavar='FILE',
+        nargs=1,
+        help='Save output as JSON into file, pass in ' "'-' to output to stdout",
+    )
+
+    (options, args) = parser.parse_args()
+
+    if options.json == '-':
+        options.json = True
+
+    show_versions(as_json=options.json)
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+xarray
+scipy
+xskillscore
+eofs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,12 @@
+[bdist_wheel]
+universal = 1
+
+[flake8]
+exclude = docs
+ignore = E203,E266,E501,W503,F401,W605,E402
+max-line-length = 88
+max-complexity = 18
+select = B,C,E,F,W,T4,B9
+
+[isort]
+line_length = 88

--- a/setup.py
+++ b/setup.py
@@ -1,30 +1,50 @@
 from setuptools import find_packages, setup
+from os.path import exists
 
-DISTNAME = 'climpred'
-VERSION = '0.3'
-AUTHOR = 'Riley X. Brady'
-AUTHOR_EMAIL = 'riley.brady@colorado.edu'
-DESCRIPTION = ('An xarray wrapper for analysis of ensemble forecast models for climate '
-               + 'prediction.')
-URL = 'https://github.com/bradyrx/climpred'
-LICENSE = 'MIT'
-INSTALL_REQUIRES = ['numpy', 'xarray', 'scipy', 'xskillscore', 'eofs']
-TESTS_REQUIRE = ['pytest']
-PYTHON_REQUIRE = '>=3.6'
+if exists('README.rst'):
+    with open('README.rst') as f:
+        long_description = f.read()
+else:
+    long_description = ''
+
+with open('requirements.txt') as f:
+    install_requires = f.read().strip().split('\n')
+
+test_requirements = ['pytest-cov']
+CLASSIFIERS = [
+    'Development Status :: 3 - Alpha',
+    'License :: OSI Approved :: MIT License',
+    'Operating System :: OS Independent',
+    'Intended Audience :: Science/Research',
+    'Programming Language :: Python :: 3 :: Only',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+]
+
 EXTRAS = {'graphics': ['matplotlib']}
 
 setup(
-    name=DISTNAME,
-    version=VERSION,
-    description=DESCRIPTION,
-    long_description=open('README.rst').read(),
-    url=URL,
-    author=AUTHOR,
-    author_email=AUTHOR_EMAIL,
-    license=LICENSE,
-    packages=find_packages(),
-    install_requires=INSTALL_REQUIRES,
-    python_requires=PYTHON_REQUIRE,
-    tests_require=TESTS_REQUIRE,
+    maintainer='Riley X. Brady and Aaron Spring',
+    maintainer_email='riley.brady@colorado.edu',
+    description='An xarray wrapper for analysis of ensemble forecast models for climate'
+    + ' prediction.',
     extras_require=EXTRAS,
+    install_requires=install_requires,
+    python_requires='>=3.6',
+    license='MIT',
+    long_description=long_description,
+    classifiers=CLASSIFIERS,
+    name='climpred',
+    packages=find_packages(),
+    test_suite='climpred/tests',
+    tests_require=test_requirements,
+    url='https://github.com/bradyrx/climpred',
+    use_scm_version={'version_scheme': 'post-release', 'local_scheme': 'dirty-tag'},
+    setup_requires=[
+        'setuptools_scm',
+        'setuptools>=30.3.0',
+        'setuptools_scm_git_archive',
+    ],
+    zip_safe=False,
 )


### PR DESCRIPTION
# Description

Uses `setuptools_scm` and follows `esmlab` conventions to allow a smart version to be printed for `climpred.` Follows suggestions from @andersy005.

Fixes https://github.com/bradyrx/climpred/issues/133

# How Has This Been Tested?

Upon pip install, you see a version:

<img width="405" alt="Screen Shot 2019-07-02 at 11 05 04 PM" src="https://user-images.githubusercontent.com/8881170/60564700-e732f680-9d1d-11e9-90ea-ba783bf4b24c.png">


Upon import, you can run `climpred.__version__`:

<img width="216" alt="Screen Shot 2019-07-02 at 11 05 16 PM" src="https://user-images.githubusercontent.com/8881170/60564697-e601c980-9d1d-11e9-83fe-ff765ab6a811.png">

This currently says 0.0 since I don't have any formal tags/releases set up. The post573 is the number of commits we have here (with the extra layered ones from this PR).