### PR TITLE
Fix lead zero calculations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Changelog History
 climpred v1.0.1 (2019-07-04)
 ============================
 
+Bug Fixes
+---------
+- Accomodate for lead-zero within the ``lead`` dimension (:pr:`196`) `Riley X. Brady`_.
+
 Internals/Minor Fixes
 ---------------------
 - Force ``xskillscore`` version 0.0.4 or higher to avoid ``ImportError`` (:pr:`204`) `Riley X. Brady`_.

--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -1,4 +1,3 @@
-import numpy as np
 import xarray as xr
 
 from .checks import is_xarray
@@ -168,9 +167,7 @@ def compute_persistence(hind, reference, metric='pearson_r', max_dfs=False):
 
 
 @is_xarray([0, 1])
-def compute_uninitialized(
-    uninit, reference, metric='pearson_r', comparison='e2r', nlags=None
-):
+def compute_uninitialized(uninit, reference, metric='pearson_r', comparison='e2r'):
     """Compute a predictability score between an uninitialized ensemble and a reference.
 
     .. note::
@@ -188,9 +185,6 @@ def compute_uninitialized(
             How to compare the uninitialized ensemble to the reference:
                 * e2r : ensemble mean to reference (Default)
                 * m2r : each member to the reference
-        nlags (int):
-            Number of lags to broadcast to. The metric is only computed to the first
-            lag and then broadcasted forward to this many lags.
 
     Returns:
         u (xarray object): Results from comparison at the first lag.
@@ -204,9 +198,4 @@ def compute_uninitialized(
     forecast = forecast.sel(time=common_time)
     reference = reference.sel(time=common_time)
     u = metric(forecast, reference, dim='time', comparison=comparison)
-    if nlags is None:
-        return u
-    else:
-        u = xr.concat([u] * nlags, dim='lead')
-        u['lead'] = np.arange(1, nlags + 1)
-        return u
+    return u

--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -23,7 +23,7 @@ from .utils import (
 # predictability.
 # --------------------------------------------#
 @is_xarray([0, 1])
-def compute_perfect_model(ds, control, metric='rmse', comparison='m2e'):
+def compute_perfect_model(ds, control, metric='pearson_r', comparison='m2e'):
     """
     Compute a predictability skill score for a perfect-model framework
     simulation dataset.
@@ -88,7 +88,7 @@ def compute_hindcast(
             Predictability with main dimension ``lag``
 
     """
-    nlags = hind.lead.size
+    nlags = max(hind.lead.values)
     comparison = get_comparison_function(comparison, HINDCAST_COMPARISONS)
     metric = get_metric_function(metric, HINDCAST_METRICS)
 

--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -141,6 +141,12 @@ def compute_persistence(hind, reference, metric='pearson_r', max_dfs=False):
           Oxford University Press, 2007.
     """
     metric = get_metric_function(metric, HINDCAST_METRICS)
+    # If lead 0, need to make modifications to get proper persistence, since persistence
+    # at lead 0 is == 1.
+    if [0] in hind.lead.values:
+        hind = hind.copy()
+        hind['lead'] += 1
+        hind['init'] -= 1
     nlags = max(hind.lead.values)
     # temporarily change `init` to `time` for comparison to reference time.
     hind = hind.rename({'init': 'time'})
@@ -197,5 +203,5 @@ def compute_uninitialized(uninit, reference, metric='pearson_r', comparison='e2r
     common_time = intersect(forecast['time'].values, reference['time'].values)
     forecast = forecast.sel(time=common_time)
     reference = reference.sel(time=common_time)
-    u = metric(forecast, reference, dim='time', comparison=comparison)
-    return u
+    uninit = metric(forecast, reference, dim='time', comparison=comparison)
+    return uninit

--- a/climpred/tests/test_hindcast_prediction.py
+++ b/climpred/tests/test_hindcast_prediction.py
@@ -153,6 +153,19 @@ def test_persistence(initialized_da, reconstruction_da, metric):
 
 
 @pytest.mark.parametrize('metric', PM_METRICS)
+def test_persistence_lead0_lead1(
+    initialized_ds, initialized_ds_lead0, reconstruction_ds, metric
+):
+    """
+    Checks that compute persistence returns the same results with a lead-0 and lead-1
+    framework.
+    """
+    res1 = compute_persistence(initialized_ds, reconstruction_ds, metric=metric)
+    res2 = compute_persistence(initialized_ds_lead0, reconstruction_ds, metric=metric)
+    assert (res1.SST.values == res2.SST.values).all()
+
+
+@pytest.mark.parametrize('metric', PM_METRICS)
 @pytest.mark.parametrize('comparison', HINDCAST_COMPARISONS)
 def test_uninitialized(uninitialized_da, reconstruction_da, metric, comparison):
     """

--- a/climpred/tests/test_hindcast_prediction.py
+++ b/climpred/tests/test_hindcast_prediction.py
@@ -16,15 +16,23 @@ from climpred.tutorial import load_dataset
 @pytest.fixture
 def initialized_ds():
     da = load_dataset('CESM-DP-SST')
-    da = da.sel(init=slice(1955, 2015))
     da = da - da.mean('init')
+    return da
+
+
+@pytest.fixture
+def initialized_ds_lead0():
+    da = load_dataset('CESM-DP-SST')
+    da = da - da.mean('init')
+    # Change to a lead-0 framework
+    da['init'] += 1
+    da['lead'] -= 1
     return da
 
 
 @pytest.fixture
 def initialized_da():
     da = load_dataset('CESM-DP-SST')['SST']
-    da = da.sel(init=slice(1955, 2015))
     da = da - da.mean('init')
     return da
 
@@ -46,8 +54,6 @@ def observations_da():
 @pytest.fixture
 def reconstruction_ds():
     da = load_dataset('FOSI-SST')
-    # same timeframe as DPLE
-    da = da.sel(time=slice(1955, 2015))
     da = da - da.mean('time')
     return da
 
@@ -55,8 +61,6 @@ def reconstruction_ds():
 @pytest.fixture
 def reconstruction_da():
     da = load_dataset('FOSI-SST')['SST']
-    # same timeframe as DPLE
-    da = da.sel(time=slice(1955, 2015))
     da = da - da.mean('time')
     return da
 
@@ -104,7 +108,7 @@ def test_compute_hindcast_less_m2r(initialized_da, reconstruction_da):
 @pytest.mark.parametrize('comparison', HINDCAST_COMPARISONS)
 def test_compute_hindcast(initialized_ds, reconstruction_ds, metric, comparison):
     """
-    Checks that compute reference works without breaking.
+    Checks that compute hindcast works without breaking.
     """
     res = (
         compute_hindcast(
@@ -115,6 +119,24 @@ def test_compute_hindcast(initialized_ds, reconstruction_ds, metric, comparison)
     )
     for var in res.data_vars:
         assert not res[var]
+
+
+@pytest.mark.parametrize('metric', PM_METRICS)
+@pytest.mark.parametrize('comparison', HINDCAST_COMPARISONS)
+def test_compute_hindcast_lead0_lead1(
+    initialized_ds, initialized_ds_lead0, reconstruction_ds, metric, comparison
+):
+    """
+    Checks that compute hindcast returns the same results with a lead-0 and lead-1
+    framework.
+    """
+    res1 = compute_hindcast(
+        initialized_ds, reconstruction_ds, metric=metric, comparison=comparison
+    )
+    res2 = compute_hindcast(
+        initialized_ds_lead0, reconstruction_ds, metric=metric, comparison=comparison
+    )
+    assert (res1.SST.values == res2.SST.values).all()
 
 
 @pytest.mark.parametrize('metric', PM_METRICS)

--- a/climpred/tests/test_hindcast_prediction.py
+++ b/climpred/tests/test_hindcast_prediction.py
@@ -138,11 +138,7 @@ def test_uninitialized(uninitialized_da, reconstruction_da, metric, comparison):
     """
     res = (
         compute_uninitialized(
-            uninitialized_da,
-            reconstruction_da,
-            metric=metric,
-            comparison=comparison,
-            nlags=5,
+            uninitialized_da, reconstruction_da, metric=metric, comparison=comparison
         )
         .isnull()
         .any()

--- a/climpred/tests/test_perfect_model_prediction.py
+++ b/climpred/tests/test_perfect_model_prediction.py
@@ -16,6 +16,16 @@ def PM_da_ds1d():
 
 
 @pytest.fixture
+def PM_da_ds1d_lead0():
+    da = load_dataset('MPI-PM-DP-1D')
+    da = da['tos'].isel(area=1, period=-1)
+    # Convert to lead zero for testing
+    da['lead'] -= 1
+    da['init'] += 1
+    return da
+
+
+@pytest.fixture
 def PM_da_control1d():
     da = load_dataset('MPI-control-1D')
     da = da['tos'].isel(area=1, period=-1)
@@ -71,7 +81,7 @@ def test_compute_perfect_model_da1d_not_nan(
     PM_da_ds1d, PM_da_control1d, comparison, metric
 ):
     """
-    Checks that there are no NaNs on persistence forecast of 1D time series.
+    Checks that there are no NaNs on perfect model metrics of 1D time series.
     """
     actual = (
         compute_perfect_model(
@@ -81,6 +91,23 @@ def test_compute_perfect_model_da1d_not_nan(
         .any()
     )
     assert not actual
+
+
+@pytest.mark.parametrize('comparison', PM_COMPARISONS)
+@pytest.mark.parametrize('metric', PM_METRICS)
+def test_compute_perfect_model_lead0_lead1(
+    PM_da_ds1d, PM_da_ds1d_lead0, PM_da_control1d, comparison, metric
+):
+    """
+    Checks that metric results are identical for a lead 0 and lead 1 setup.
+    """
+    res1 = compute_perfect_model(
+        PM_da_ds1d, PM_da_control1d, comparison=comparison, metric=metric
+    )
+    res2 = compute_perfect_model(
+        PM_da_ds1d_lead0, PM_da_control1d, comparison=comparison, metric=metric
+    )
+    assert (res1.values == res2.values).all()
 
 
 @pytest.mark.parametrize('comparison', PM_COMPARISONS)

--- a/climpred/tests/test_perfect_model_prediction.py
+++ b/climpred/tests/test_perfect_model_prediction.py
@@ -75,6 +75,18 @@ def test_compute_persistence_ds1d_not_nan(PM_ds_ds1d, PM_ds_control1d, metric):
         assert not actual[var]
 
 
+@pytest.mark.parametrize('metric', PM_METRICS)
+def test_compute_persistence_lead0_lead1(
+    PM_da_ds1d, PM_da_ds1d_lead0, PM_da_control1d, metric
+):
+    """
+    Checks that persistence forecast results are identical for a lead 0 and lead 1 setup
+    """
+    res1 = compute_persistence(PM_da_ds1d, PM_da_control1d, metric=metric)
+    res2 = compute_persistence(PM_da_ds1d_lead0, PM_da_control1d, metric=metric)
+    assert (res1.values == res2.values).all()
+
+
 @pytest.mark.parametrize('comparison', PM_COMPARISONS)
 @pytest.mark.parametrize('metric', PM_METRICS)
 def test_compute_perfect_model_da1d_not_nan(


### PR DESCRIPTION
# Description

This PR makes minor fixes to ensure that a lead-0 setup works. I.e., if you have a lead time starting with zero instead of one.

* Adds lead0/lead1 tests for perfect model, hindcast, and persistence.
* Removes `nlags` argument for uninitialized (this seems like something the user can handle broadcasting forward. Especially since we don't know what leads to attach to it)
* Adds lines to `compute_persistence` to handle a case where it receives a lead 0 starting time series
* Adds lead0/lead1 compatability to `compute_hindcast`

## Type of change

Please delete options that are not relevant.

-   [X]  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Hindcast**:

![Screen Shot 2019-07-03 at 2 03 17 PM](https://user-images.githubusercontent.com/8881170/60621630-5f8bcd00-9d9b-11e9-8e78-4a39165cd74f.png)

**Perfect Model**:

![Screen Shot 2019-07-03 at 2 04 15 PM](https://user-images.githubusercontent.com/8881170/60621657-7500f700-9d9b-11e9-9328-125556d45731.png)

**Persistence**:

![Screen Shot 2019-07-03 at 2 51 20 PM](https://user-images.githubusercontent.com/8881170/60624259-0bd0b200-9da2-11e9-810f-1234b85fa404.png)


## Checklist (while developing)

-   [X]  I have commented my code, particularly in hard-to-understand areas
-   [X]  Tests added for `pytest`, if necessary.

## Pre-Merge Checklist (final steps)

-   [X]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [X]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

## References

Please add any references to manuscripts, textbooks, etc.
