### PR TITLE
Fix xskillscore version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog History
 =================
 
+climpred v1.0.1 (2019-07-04)
+============================
+
+Internals/Minor Fixes
+---------------------
+- Force ``xskillscore`` version 0.0.4 or higher to avoid ``ImportError`` (:pr:`204`) `Riley X. Brady`_.
+
 climpred v1.0.0 (2019-07-03)
 ============================
 ``climpred`` v1.0.0 represents the first stable release of the package. It includes ``HindcastEnsemble`` and ``PerfectModelEnsemble`` objects to perform analysis with. It offers a suite of deterministic and probabilistic metrics that are optimized to be run on single time series or grids of data (e.g., lat, lon, and depth). Currently, ``climpred`` only supports annual forecasts.

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -19,7 +19,7 @@ dependencies:
   - nbsphinx
   - pip
   - pip:
-    - git+https://github.com/raybellwaves/xskillscore
+    - xskillscore>=0.0.4
     - pytest-cov
     - coveralls
     - sphinxcontrib-napoleon

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 xarray
 scipy
-xskillscore
+xskillscore>=0.0.4
 eofs


### PR DESCRIPTION
# Description

Quick fix to force version 0.0.4 of `xskillscore` on climpred to avoid `ImportError` from needing the newer probabilistic metrics.

Fixes https://github.com/bradyrx/climpred/issues/203

## Type of change

-   [X]  Bug fix (non-breaking change which fixes an issue)