### PR TITLE
add matplotlib as a main dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - conda list
   - which conda
   - which python
-  - pip install .['graphics']
+  - pip install .
   - python setup.py install --user
   - pip install pytest-cov
   - pip install coveralls

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog History
 =================
 
+climpred v1.0.2 (2019-07-##)
+============================
+
+Internals/Minor Fixes
+---------------------
+- Add `matplotlib` as a main dependency so that a direct pip installation works (:pr:`211`) `Riley X. Brady`_.
+
 climpred v1.0.1 (2019-07-04)
 ============================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ xarray
 scipy
 xskillscore>=0.0.4
 eofs
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,11 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.8',
 ]
 
-EXTRAS = {'graphics': ['matplotlib']}
-
 setup(
     maintainer='Riley X. Brady and Aaron Spring',
     maintainer_email='riley.brady@colorado.edu',
     description='An xarray wrapper for analysis of ensemble forecast models for climate'
     + ' prediction.',
-    extras_require=EXTRAS,
     install_requires=install_requires,
     python_requires='>=3.6',
     license='MIT',


### PR DESCRIPTION
This adds matplotlib as a main dependency. Currently it is listed as an optional dependency under `.graphics` installation. But since it is imported in one of our main modules, `import climpred` breaks if the standard pip installation is used. (This was pointed out as I was setting up our conda installation here https://github.com/conda-forge/staged-recipes/pull/8822).