### PR TITLE
bugfix attrs print and performence bootstrapping only once set attrs

### DIFF
--- a/climpred/bootstrap.py
+++ b/climpred/bootstrap.py
@@ -287,14 +287,28 @@ def bootstrap_compute(
         smp = np.random.choice(inits, len(inits))
         smp_hind = hind.sel(init=smp)
         # compute init skill
-        init.append(compute(smp_hind, reference, metric=metric, comparison=comparison))
+        init.append(
+            compute(
+                smp_hind,
+                reference,
+                metric=metric,
+                comparison=comparison,
+                add_attrs=False,
+            )
+        )
         # generate uninitialized ensemble from hist
         if hist is None:  # PM path, use reference = control
             hist = reference
         uninit_hind = resample_uninit(hind, hist)
         # compute uninit skill
         uninit.append(
-            compute(uninit_hind, reference, metric=metric, comparison=comparison)
+            compute(
+                uninit_hind,
+                reference,
+                metric=metric,
+                comparison=comparison,
+                add_attrs=False,
+            )
         )
         # compute persistence skill
         pers.append(compute_persistence(smp_hind, reference, metric=metric))

--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -25,7 +25,9 @@ from .utils import (
 # predictability.
 # --------------------------------------------#
 @is_xarray([0, 1])
-def compute_perfect_model(ds, control, metric='pearson_r', comparison='m2e'):
+def compute_perfect_model(
+    ds, control, metric='pearson_r', comparison='m2e', add_attrs=True
+):
     """
     Compute a predictability skill score for a perfect-model framework
     simulation dataset.
@@ -36,6 +38,7 @@ def compute_perfect_model(ds, control, metric='pearson_r', comparison='m2e'):
         metric (str): `metric` name, see :py:func:`climpred.utils.get_metric_function`.
         comparison (str): `comparison` name, see
                           :py:func:`climpred.utils.get_comparison_function`.
+        add_attrs (bool): write climpred compute args to attrs. default: True
 
     Returns:
         skill (xarray object): skill score.
@@ -49,19 +52,20 @@ def compute_perfect_model(ds, control, metric='pearson_r', comparison='m2e'):
 
     skill = metric(forecast, reference, dim=supervector_dim, comparison=comparison)
     # Attach climpred compute information to skill
-    skill = assign_attrs(
-        skill,
-        ds,
-        function_name=inspect.stack()[0][3],
-        metric=metric,
-        comparison=comparison,
-    )
+    if add_attrs:
+        skill = assign_attrs(
+            skill,
+            ds,
+            function_name=inspect.stack()[0][3],
+            metric=metric,
+            comparison=comparison,
+        )
     return skill
 
 
 @is_xarray([0, 1])
 def compute_hindcast(
-    hind, reference, metric='pearson_r', comparison='e2r', max_dof=False
+    hind, reference, metric='pearson_r', comparison='e2r', max_dof=False, add_attrs=True
 ):
     """Compute a predictability skill score against a reference
 
@@ -92,6 +96,8 @@ def compute_hindcast(
             If False (default), then slice to a common time frame prior to computing
             metric. This philosophy follows the thought that each lead should be based
             on the same set of initializations.
+        add_attrs (bool): write climpred compute args to attrs. default: True
+
 
     Returns:
         skill (xarray object):
@@ -123,13 +129,14 @@ def compute_hindcast(
     skill = xr.concat(plag, 'lead')
     skill['lead'] = forecast.lead.values
     # Attach climpred compute information to skill
-    skill = assign_attrs(
-        skill,
-        hind,
-        function_name=inspect.stack()[0][3],
-        metric=metric,
-        comparison=comparison,
-    )
+    if add_attrs:
+        skill = assign_attrs(
+            skill,
+            hind,
+            function_name=inspect.stack()[0][3],
+            metric=metric,
+            comparison=comparison,
+        )
     return skill
 
 
@@ -192,7 +199,9 @@ def compute_persistence(hind, reference, metric='pearson_r', max_dof=False):
 
 
 @is_xarray([0, 1])
-def compute_uninitialized(uninit, reference, metric='pearson_r', comparison='e2r'):
+def compute_uninitialized(
+    uninit, reference, metric='pearson_r', comparison='e2r', add_attrs=True
+):
     """Compute a predictability score between an uninitialized ensemble and a reference.
 
     .. note::
@@ -210,6 +219,8 @@ def compute_uninitialized(uninit, reference, metric='pearson_r', comparison='e2r
             How to compare the uninitialized ensemble to the reference:
                 * e2r : ensemble mean to reference (Default)
                 * m2r : each member to the reference
+        add_attrs (bool): write climpred compute args to attrs. default: True
+
 
     Returns:
         u (xarray object): Results from comparison at the first lag.
@@ -224,11 +235,12 @@ def compute_uninitialized(uninit, reference, metric='pearson_r', comparison='e2r
     reference = reference.sel(time=common_time)
     uninit_skill = metric(forecast, reference, dim='time', comparison=comparison)
     # Attach climpred compute information to skill
-    uninit_skill = assign_attrs(
-        uninit_skill,
-        uninit,
-        function_name=inspect.stack()[0][3],
-        metric=metric,
-        comparison=comparison,
-    )
+    if add_attrs:
+        uninit_skill = assign_attrs(
+            uninit_skill,
+            uninit,
+            function_name=inspect.stack()[0][3],
+            metric=metric,
+            comparison=comparison,
+        )
     return uninit_skill

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -140,7 +140,6 @@ def assign_attrs(
         '_'
     )
     metric = get_metric_function(metric, ALL_METRICS).__name__.lstrip('_')
-    print(metric)
     skill.attrs['metric'] = metric
     skill.attrs['comparison'] = comparison
 


### PR DESCRIPTION
# Description

- bugfix attrs print 
- performence bootstrapping only once set attrs

Please delete options that are not relevant.

-   [x]  Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here.

## Checklist (while developing)

-   [ ]  I have added docstrings to all new functions.
-   [ ]  I have commented my code, particularly in hard-to-understand areas
-   [ ]  Tests added for `pytest`, if necessary.
-   [ ]  I have updated the sphinx documentation, if necessary.

## Pre-Merge Checklist (final steps)

-   [ ]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.
-   [ ]  I have run `make html` on the documents to make sure example notebooks still compile.

## References

Please add any references to manuscripts, textbooks, etc.
