### PR TITLE
Implementation of `asv` benchmarking

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Internals/Minor Fixes
 - Add `matplotlib` as a main dependency so that a direct pip installation works (:pr:`211`) `Riley X. Brady`_.
 - ``climpred`` is now installable from conda-forge (:pr:`212`) `Riley X. Brady`_.
 - Fix erroneous descriptions of sample datasets (:pr:`226`) `Riley X. Brady`_.
-- Benchmarking time and peak memory of compute functions with `asv` (:pr:`2xx`) `Aaron Spring`_
+- Benchmarking time and peak memory of compute functions with `asv` (:pr:`231`) `Aaron Spring`_
 
 Documentation
 -------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Internals/Minor Fixes
 - Add `matplotlib` as a main dependency so that a direct pip installation works (:pr:`211`) `Riley X. Brady`_.
 - ``climpred`` is now installable from conda-forge (:pr:`212`) `Riley X. Brady`_.
 - Fix erroneous descriptions of sample datasets (:pr:`226`) `Riley X. Brady`_.
+- Benchmarking time and peak memory of compute functions with `asv` (:pr:`2xx`) `Aaron Spring`_
 
 Documentation
 -------------

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -1,0 +1,166 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "project",
+
+    // The project's homepage
+    "project_url": "https://climpred.readthedocs.io/",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": "..",
+
+    // The Python project's subdirectory in your repo.  If missing or
+    // the empty string, the project is assumed to be located at the root
+    // of the repository.
+    // "repo_subdir": "",
+
+    // Customizable commands for building, installing, and
+    // uninstalling the project. See asv.conf.json documentation.
+    //
+    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
+    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+    // "build_command": [
+    //     "python setup.py build",
+    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    // ],
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "default" (for mercurial).
+    // "branches": ["master"], // for git
+    // "branches": ["default"],    // for mercurial
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    // "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "conda",
+
+    // timeout in seconds for installing any dependencies in environment
+    // defaults to 10 min
+    //"install_timeout": 600,
+
+    // the base URL to show a commit for the project.
+    // "show_commit_url": "http://github.com/bradyrx/climpred/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    // "pythons": ["3.6"],
+
+    // The list of conda channel names to be searched for benchmark
+    // dependency packages in the specified order
+    // "conda_channels": ["conda-forge", "defaults"],
+
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list or empty string indicates to just test against the default
+    // (latest) version. null indicates that the package is to not be
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed via
+    // pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
+    //
+    // "matrix": {
+    //     "numpy": ["1.6", "1.7"],
+    //     "six": ["", null],        // test with and without six installed
+    //     "pip+emcee": [""],   // emcee is only available for install with pip.
+    // },
+    "matrix": {
+      "numpy": [""],
+      "xarray": [""],
+      "dask": [""],
+      "xskillscore": [""],
+    },
+
+    // Combinations of libraries/python versions can be excluded/included
+    // from the set to test. Each entry is a dictionary containing additional
+    // key-value pairs to include/exclude.
+    //
+    // An exclude entry excludes entries where all values match. The
+    // values are regexps that should match the whole string.
+    //
+    // An include entry adds an environment. Only the packages listed
+    // are installed. The 'python' key is required. The exclude rules
+    // do not apply to includes.
+    //
+    // In addition to package names, the following keys are available:
+    //
+    // - python
+    //     Python version, as in the *pythons* variable above.
+    // - environment_type
+    //     Environment type, as above.
+    // - sys_platform
+    //     Platform, as in sys.platform. Possible values for the common
+    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    //
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "six": null}, // don't run without six on conda
+    // ],
+    //
+    // "include": [
+    //     // additional env for python2.7
+    //     {"python": "2.7", "numpy": "1.8"},
+    //     // additional env if run on windows+conda
+    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
+    // ],
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    // "benchmark_dir": "benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": ".asv/env",
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": ".asv/results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": ".asv/html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache results of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // the number of builds to keep, per environment.
+    // "build_cache_size": 2,
+
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // },
+
+    // The thresholds for relative change in results, after which `asv
+    // publish` starts reporting regressions. Dictionary of the same
+    // form as in ``regressions_first_commits``, with values
+    // indicating the thresholds.  If multiple entries match, the
+    // maximum is taken. If no entry matches, the default is 5%.
+    //
+    // "regressions_thresholds": {
+    //    "some_benchmark": 0.01,     // Threshold of 1%
+    //    "another_benchmark": 0.5,   // Threshold of 50%
+    // },
+}

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -4,7 +4,7 @@
     "version": 1,
 
     // The name of the project being benchmarked
-    "project": "project",
+    "project": "climpred",
 
     // The project's homepage
     "project_url": "https://climpred.readthedocs.io/",

--- a/asv_bench/benchmarks/__init__.py
+++ b/asv_bench/benchmarks/__init__.py
@@ -1,0 +1,49 @@
+# https://github.com/pydata/xarray/blob/master/asv_bench/benchmarks/__init__.py
+import itertools
+
+import numpy as np
+
+_counter = itertools.count()
+
+
+def parameterized(names, params):
+    def decorator(func):
+        func.param_names = names
+        func.params = params
+        return func
+
+    return decorator
+
+
+def requires_dask():
+    try:
+        import dask  # noqa
+    except ImportError:
+        raise NotImplementedError
+
+
+def randn(shape, frac_nan=None, chunks=None, seed=0):
+    rng = np.random.RandomState(seed)
+    if chunks is None:
+        x = rng.standard_normal(shape)
+    else:
+        import dask.array as da
+
+        rng = da.random.RandomState(seed)
+        x = rng.standard_normal(shape, chunks=chunks)
+
+    if frac_nan is not None:
+        inds = rng.choice(range(x.size), int(x.size * frac_nan))
+        x.flat[inds] = np.nan
+
+    return x
+
+
+def randint(low, high=None, size=None, frac_minus=None, seed=0):
+    rng = np.random.RandomState(seed)
+    x = rng.randint(low, high, size)
+    if frac_minus is not None:
+        inds = rng.choice(range(x.size), int(x.size * frac_minus))
+        x.flat[inds] = -1
+
+    return x

--- a/asv_bench/benchmarks/benchmarks_perfect_model.py
+++ b/asv_bench/benchmarks/benchmarks_perfect_model.py
@@ -1,0 +1,123 @@
+# Write the benchmarking functions here.
+# See "Writing benchmarks" in the asv docs for more information.
+
+
+import xarray as xr
+import numpy as np
+from . import randn, parameterized
+
+from climpred.prediction import compute_perfect_model
+from climpred.bootstrap import bootstrap_perfect_model
+from climpred.constants import PM_COMPARISONS, PM_METRICS
+
+# faster
+PM_METRICS = ['rmse', 'pearson_r', 'crpss']
+# PM_COMPARISONS = ['m2e', 'e2c']
+
+
+class Generate:
+    """
+    Generate random ds, control to be benckmarked.
+    """
+
+    timeout = 600
+    repeat = (2, 5, 20)
+
+    def make_ds(self):
+
+        # ds
+        self.ds = xr.Dataset()
+        self.nmember = 3
+        self.ninit = 4
+        self.nlead = 3
+        self.nx = 90  # 4 deg
+        self.ny = 45  # 4 deg
+        self.control_start = 3000
+        self.control_end = 3300
+        self.ntime = 300
+
+        frac_nan = 0.0
+
+        # control
+        self.control = xr.Dataset()
+
+        times = np.arange(self.control_start, self.control_end)
+        leads = np.arange(1, 1 + self.nlead)
+        members = np.arange(1, 1 + self.nmember)
+        inits = list(
+            np.random.randint(self.control_start, self.control_end + 1, self.ninit)
+        )
+
+        lons = xr.DataArray(
+            np.linspace(0, 360, self.nx),
+            dims=('lon',),
+            attrs={'units': 'degrees east', 'long_name': 'longitude'},
+        )
+        lats = xr.DataArray(
+            np.linspace(-90, 90, self.ny),
+            dims=('lat',),
+            attrs={'units': 'degrees north', 'long_name': 'latitude'},
+        )
+        self.ds['tos'] = xr.DataArray(
+            randn(
+                (self.nmember, self.ninit, self.nlead, self.nx, self.ny),
+                frac_nan=frac_nan,
+            ),
+            coords={
+                'member': members,
+                'init': inits,
+                'lon': lons,
+                'lat': lats,
+                'lead': leads,
+            },
+            dims=('member', 'init', 'lead', 'lon', 'lat'),
+            name='tos',
+            encoding=None,
+            attrs={'units': 'foo units', 'description': 'a description'},
+        )
+        self.control['tos'] = xr.DataArray(
+            randn((self.ntime, self.nx, self.ny), frac_nan=frac_nan),
+            coords={'lon': lons, 'lat': lats, 'time': times},
+            dims=('time', 'lon', 'lat'),
+            name='tos',
+            encoding=None,
+            attrs={'units': 'foo units', 'description': 'a description'},
+        )
+
+        self.ds.attrs = {'history': 'created for xarray benchmarking'}
+
+
+class Compute(Generate):
+    """
+    A few examples that benchmark climpred compute_perfect_model.
+    """
+
+    def setup(self, *args, **kwargs):
+        self.make_ds()
+
+    @parameterized(['metric', 'comparison'], (PM_METRICS, PM_COMPARISONS))
+    def time_compute_perfect_model(self, metric, comparison):
+        """Take time for compute_perfect_model."""
+        compute_perfect_model(
+            self.ds, self.control, metric=metric, comparison=comparison
+        )
+
+    @parameterized(['metric', 'comparison'], (['pearson_r', 'crpss'], PM_COMPARISONS))
+    def peakmem_compute_perfect_model(self, metric, comparison):
+        """Take memory peak for compute_perfect_model for all comparisons."""
+        compute_perfect_model(
+            self.ds, self.control, metric=metric, comparison=comparison
+        )
+
+    def time_bootstrap_perfect_model(self):
+        """Take time for bootstrap_perfect_model for one metric."""
+        bootstrap_perfect_model(
+            self.ds, self.control, metric='mae', comparison='e2c', bootstrap=5
+        )
+
+    @parameterized(['metric', 'comparison'], (['pearson_r', 'crpss'], PM_COMPARISONS))
+    def peakmem_bootstrap_perfect_model(self, metric, comparison):
+        """Take memory peak for bootstrap_perfect_model."""
+        bootstrap_perfect_model(
+            self.ds, self.control, metric=metric, comparison=comparison, bootstrap=5
+        )

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -27,3 +27,4 @@ dependencies:
     - importlib_metadata
     - sphinx-automodapi
     - pre-commit
+    - asv


### PR DESCRIPTION
# Description

`asv` benchmarking implemented. See https://asv.readthedocs.io/en/stable/using.html.

# Open questions
-   [ ]  How and where to host benchmarks? `xarray` hosts with `pandas` see https://raw.githubusercontent.com/pydata/xarray/master/README.rst
-   [ ]   Who runs benckmarks? just one person or many? do we write different benchmarks to use for supercomputers like mistral or chayenne? Can we include `asv` into CI?
-   [ ]   What are functions to be benchmarked? `compute_` and `bootstrap_`, but probably one metric might be enough for bootstrapping

# what will benchmarking bring us?
- we will be aware of performance drops after commits
- we can optimize time and memory consumption of `compute_` and `bootstrap_`

# Future PRs
- reduce time and peakmem of `compute_` and `bootstrap_`

## Type of change

Please delete options that are not relevant.

-   [x]  New feature (non-breaking change which adds functionality)


## References

https://github.com/pydata/xarray/tree/master/asv_bench/benchmarks

# How it looks like


<details>
asv show master
Commit: f7dc84a8 <benchmark>

benchmarks_perfect_model.Compute.peakmem_bootstrap_perfect_model [MacBookProAaron/conda-py3.6-dask-numpy-xarray-xskillscore]
  ok
  =========== ====== ====== ====== ======
  --                   comparison
  ----------- ---------------------------
     metric    m2c    e2c    m2m    m2e
  =========== ====== ====== ====== ======
   pearson_r   186M   186M   186M   185M
     crpss     186M   186M   186M   186M
  =========== ====== ====== ====== ======
  started: 2019-08-26 15:25:13, duration: 40.3s

benchmarks_perfect_model.Compute.peakmem_compute_perfect_model [MacBookProAaron/conda-py3.6-dask-numpy-xarray-xskillscore]
  ok
  =========== ====== ====== ====== ======
  --                   comparison
  ----------- ---------------------------
     metric    m2c    e2c    m2m    m2e
  =========== ====== ====== ====== ======
   pearson_r   186M   186M   186M   186M
     crpss     186M   186M   186M   186M
  =========== ====== ====== ====== ======
  started: 2019-08-26 15:25:53, duration: 13.1s

benchmarks_perfect_model.Compute.time_bootstrap_perfect_model [MacBookProAaron/conda-py3.6-dask-numpy-xarray-xskillscore]
  2.96±0.07s
  started: 2019-08-26 15:26:06, duration: 20.5s

benchmarks_perfect_model.Compute.time_compute_perfect_model [MacBookProAaron/conda-py3.6-dask-numpy-xarray-xskillscore]
  ok
  =========== ============ ============ ============ ============
  --                               comparison
  ----------- ---------------------------------------------------
     metric       m2c          e2c          m2m          m2e
  =========== ============ ============ ============ ============
      rmse     13.7±0.4ms   9.25±0.1ms   31.8±0.4ms   24.3±0.5ms
   pearson_r    16.0±2ms    11.3±0.4ms   35.8±0.3ms    31.4±3ms
     crpss      30.5±2ms    21.6±0.7ms   58.2±0.9ms   40.8±0.5ms
  =========== ============ ============ ============ ============
  started: 2019-08-26 15:26:27, duration: 36.1s

</details>

## website

`asv preview`

![image](https://user-images.githubusercontent.com/12237157/63695381-dfbd3480-c818-11e9-9dd0-90bb462a37be.png)

