### PR TITLE
Add scope to docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog History
 =================
 
-climpred v1.0.2 (2019-07-##)
+climpred v1.1 (2019-08-##)
 ============================
 
 Features
@@ -14,6 +14,10 @@ Internals/Minor Fixes
 - Add `matplotlib` as a main dependency so that a direct pip installation works (:pr:`211`) `Riley X. Brady`_.
 - ``climpred`` is now installable from conda-forge (:pr:`212`) `Riley X. Brady`_.
 - Fix erroneous descriptions of sample datasets (:pr:`226`) `Riley X. Brady`_.
+
+Documentation
+-------------
+- Add scope of package to docs for clarity for users and developers. (:pr:`235`) `Riley X. Brady`_.
 
 climpred v1.0.1 (2019-07-04)
 ============================

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -26,3 +26,4 @@ dependencies:
     - sphinxcontrib-napoleon
     - importlib_metadata
     - sphinx-automodapi
+    - pre-commit

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,6 +55,7 @@ You can also install the bleeding edge (pre-release versions) by cloning this re
 
 
 * :doc:`why-climpred`
+* :doc:`scope` 
 * :doc:`quick-start`
 * :doc:`examples`
 
@@ -64,6 +65,7 @@ You can also install the bleeding edge (pre-release versions) by cloning this re
     :caption: Getting Started
 
     why-climpred
+    scope
     quick-start.ipynb
     examples
 

--- a/docs/source/scope.rst
+++ b/docs/source/scope.rst
@@ -1,0 +1,8 @@
+Scope of ``climpred``
+=====================
+
+``climpred`` aims to be the primary package used to analyze output from initialized dynamical forecast models, ranging from short-term weather forecasts to decadal climate forecasts. The code base will be driven entirely by the geoscientific prediction community through open source development. It leverages ``xarray`` to keep track of core prediction ensemble dimensions (e.g., ensemble member, initialization date, and lead time) and ``dask`` to perform out-of-memory computations on large datasets. 
+
+The primary goal of climpred is to offer a comprehensive set of analysis tools for assessing the forecasts relative to references (e.g., observations, reanalysis products, control runs, baseline forecasts). This will range from simple deterministic and probabilistic verification metrics—such as mean absolute error and various skill scores—to more advanced analysis methods, such as relative entropy and mutual information. ``climpred`` expects users to handle their domain-specific post-processing of model output, so that the package can focus on the actual analysis of forecasts. 
+
+Finally, the ``climpred`` documentation will serve as a repository of unified analysis methods through jupyter notebook examples, and will also collect relevant references and literature.


### PR DESCRIPTION
# Description

This PR adds the scope of `climpred` to our docs, as reviewed by some of the developers and contributors. This will help future developers and users see the long-term vision of the package and avoid scope creep in implementing new features.
