### PR TITLE
add tqdm to docs and main requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,4 @@ numpy
 xarray
 jupyterlab
 netcdf4
+tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scipy
 xskillscore>=0.0.5
 eofs
 matplotlib
+tqdm


### PR DESCRIPTION
Quick PR to add `tqdm` to the main requirements and docs requirements since it isn't an optional package currently. "latest" docs is breaking right now because of this and `readthedocs` doesn't have a means to test out PRs just yet. This slipped through the cracks since we run `make html` from the dev branch, which has `tqdm` and `readthedocs` looks at `docs/requirements.txt`.