### PR TITLE
reset coords for varweighted mean period

### DIFF
--- a/climpred/checks.py
+++ b/climpred/checks.py
@@ -1,3 +1,4 @@
+import warnings
 from functools import wraps
 
 import xarray as xr
@@ -143,3 +144,15 @@ def match_initialized_vars(init, ref):
             f'got {init_vars} for init and {ref_vars} for ref.'
         )
     return True
+
+
+def have_same_coords(a, b):
+    """Checks that two xarray objects have the same coords and returns bool."""
+    res = True
+    for c in a.coords.merge(b.coords).coords:
+        try:
+            (a[c] == b[c]).all()
+        except KeyError:
+            warnings.warn(f'Coords are not equal in {c}.')
+            res = False
+    return res

--- a/climpred/stats.py
+++ b/climpred/stats.py
@@ -1,10 +1,10 @@
 """Objects dealing with timeseries and ensemble statistics."""
 import numpy as np
 import numpy.polynomial.polynomial as poly
-import xarray as xr
-
 import scipy.stats as ss
+import xarray as xr
 from scipy.signal import periodogram
+
 from xskillscore import pearson_r, pearson_r_p_value
 
 from .checks import has_dims, is_xarray
@@ -256,6 +256,8 @@ def varweighted_mean_period(ds, time_dim='time'):
     f, Pxx = periodogram(ds, axis=0, scaling='spectrum')
     PSD = _create_dataset(ds, f, Pxx, time_dim)
     T = PSD.sum('freq') / ((PSD * PSD.freq).sum('freq'))
+    # reset coords which were not set by create dataset
+    T = T.assign_coords(**ds.drop(time_dim).coords)
     return T
 
 

--- a/climpred/tests/test_compute_dims.py
+++ b/climpred/tests/test_compute_dims.py
@@ -3,8 +3,8 @@ from climpred.bootstrap import bootstrap_hindcast, bootstrap_perfect_model
 from climpred.constants import (
     PM_COMPARISONS,
     PROBABILISTIC_HINDCAST_COMPARISONS,
-    PROBABILISTIC_PM_COMPARISONS,
     PROBABILISTIC_METRICS,
+    PROBABILISTIC_PM_COMPARISONS,
 )
 from climpred.prediction import compute_hindcast, compute_perfect_model
 from climpred.tutorial import load_dataset

--- a/climpred/tests/test_stats.py
+++ b/climpred/tests/test_stats.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
 import xarray as xr
-
 from climpred.bootstrap import dpp_threshold, varweighted_mean_period_threshold
+from climpred.checks import have_same_coords
 from climpred.exceptions import DimensionError
 from climpred.stats import (
     autocorr,
@@ -172,6 +172,11 @@ def test_bootstrap_func_multiple_sig_levels(control_3d_NA):
     bootstrap = 5
     sig = [5, 95]
     actual = dpp_threshold(ds, bootstrap=bootstrap, sig=sig)
-    print(actual)
     assert actual['quantile'].size == len(sig)
     assert (actual.isel(quantile=0).values <= actual.isel(quantile=1)).all()
+
+
+@pytest.mark.parametrize('func', (dpp, varweighted_mean_period))
+def test_stats_func_keeps_coords(control_3d_NA, func):
+    res = func(control_3d_NA)
+    assert have_same_coords(res, control_3d_NA.drop('time'))


### PR DESCRIPTION
# Description

Reset coords in `vwmp` and add tests whether coords are kept for stats function `dpp` and `vwmp`

I tried to tackle #208 but it turns out more difficult. `init` of `hind` and `skill` are not identical, therefore the directly the same approach doesnt work. There is another fix needed but I couldnt solve it.

Fixes # (https://github.com/bradyrx/climpred/issues/208 partly

## Type of change

Please delete options that are not relevant.

-   [x]  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here.

## Checklist (while developing)

-   [x]  Tests added for `pytest`, if necessary.

## Pre-Merge Checklist (final steps)

-   [x]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [x]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

