### PR TITLE
add dask tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ climpred v1.1.1 (2019-##-##)
 Features
 --------
 - Added tests for chunking with `dask` (:pr:`258`) `Aaron Spring`_.
-- Rewrote `varweighted_mean_period` based on `xrft`. Changed `time_dim` to `dim` in `stats.varweighted_mean_period` (:pr:`258`) `Aaron Spring`_.
+- Rewrote `varweighted_mean_period` based on `xrft`. Changed `time_dim` to `dim` in `stats.varweighted_mean_period`. Keeps coords. (:pr:`258`) `Aaron Spring`_.
 - Add `dim='time'` in `stats.dpp` (:pr:`258`) `Aaron Spring`_.
 - Apply arbitrary ``xarray`` methods to ``HindcastEnsemble`` and ``PerfectModelEnsemble`` (:pr:`243`) `Riley X. Brady`_.
 - Add "getter" methods to ``HindcastEnsemble`` and ``PerfectModelEnsemble`` to retrieve ``xarray`` datasets from the objects (:pr:`243`) `Riley X. Brady`_.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ climpred v1.1.1 (2019-##-##)
 
 Features
 --------
+- Added tests for chunking with `dask` (:pr:`258`) `Aaron Spring`_.
+- Rewrote `varweighted_mean_period` based on `xrft`. Changed `time_dim` to `dim` in `stats.varweighted_mean_period` (:pr:`258`) `Aaron Spring`_.
+- Add `dim='time'` in `stats.dpp` (:pr:`258`) `Aaron Spring`_.
 - Apply arbitrary ``xarray`` methods to ``HindcastEnsemble`` and ``PerfectModelEnsemble`` (:pr:`243`) `Riley X. Brady`_.
 - Add "getter" methods to ``HindcastEnsemble`` and ``PerfectModelEnsemble`` to retrieve ``xarray`` datasets from the objects (:pr:`243`) `Riley X. Brady`_.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,6 @@ climpred v1.1.1 (2019-##-##)
 
 Features
 --------
-- Added tests for chunking with `dask` (:pr:`258`) `Aaron Spring`_.
 - Rewrote `varweighted_mean_period` based on `xrft`. Changed `time_dim` to `dim` in `stats.varweighted_mean_period`. Keeps coords. (:pr:`258`) `Aaron Spring`_.
 - Add `dim='time'` in `stats.dpp` (:pr:`258`) `Aaron Spring`_.
 - Apply arbitrary ``xarray`` methods to ``HindcastEnsemble`` and ``PerfectModelEnsemble`` (:pr:`243`) `Riley X. Brady`_.
@@ -15,11 +14,14 @@ Features
 
 Bug Fixes
 ---------
+- Add `skill` from `compute_hindcast` keeps coords of `hindcast` (:pr:`258`) `Aaron Spring`_.
 
 Internals/Minor Fixes
 ---------------------
 - Add ``tqdm`` progress bar to ``bootstrap_compute`` (:pr:`244`) `Aaron Spring`_.
 - Remove inplace behavior for ``HindcastEnsemble`` and ``PerfectModelEnsemble`` (:pr:`243`) `Riley X. Brady`_.
+- Added tests for chunking with `dask` (:pr:`258`) `Aaron Spring`_.
+
 
 Documentation
 -------------

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -31,3 +31,4 @@ dependencies:
     - importlib_metadata
     - pre-commit
     - asv
+    - xrft

--- a/climpred/bootstrap.py
+++ b/climpred/bootstrap.py
@@ -2,8 +2,8 @@ import inspect
 
 import numpy as np
 import xarray as xr
+from tqdm.auto import tqdm
 
-from tqdm import tqdm
 from .checks import has_dims
 from .constants import POSITIVELY_ORIENTED_METRICS, PROBABILISTIC_METRICS
 from .prediction import compute_hindcast, compute_perfect_model, compute_persistence

--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -6,6 +6,7 @@ import xarray as xr
 from .checks import is_in_list, is_xarray
 from .comparisons import _e2c
 from .constants import (
+    CLIMPRED_DIMS,
     DETERMINISTIC_HINDCAST_METRICS,
     HINDCAST_COMPARISONS,
     HINDCAST_METRICS,
@@ -17,6 +18,7 @@ from .constants import (
 )
 from .utils import (
     assign_attrs,
+    copy_coords_from_to,
     get_comparison_function,
     get_metric_function,
     intersect,
@@ -273,6 +275,9 @@ def compute_hindcast(
     # rename back to init
     if 'time' in skill.dims:  # when dim was 'member'
         skill = skill.rename({'time': 'init'})
+    # keep coords from hind
+    drop_dims = [d for d in hind.coords if d in CLIMPRED_DIMS]
+    skill = copy_coords_from_to(hind.drop(drop_dims), skill)
     # attach climpred compute information to skill
     if add_attrs:
         skill = assign_attrs(

--- a/climpred/stats.py
+++ b/climpred/stats.py
@@ -252,9 +252,8 @@ def varweighted_mean_period(da, dim='time', **kwargs):
     if isinstance(da, xr.Dataset):
         da = da[list(da.data_vars)[0]]
         print('convert xr.Dataset to xr.DataArray.')
-    dim = dim if isinstance(dim, list) else [dim]
     da = da.fillna(0.0)
-    ps = power_spectrum(da, dim=dim, **kwargs)
+    ps = power_spectrum(da, dim=[dim], **kwargs)
     # take pos freqs
     ps = ps.where(ps[f'freq_{dim}'] > 0)
     # weighted average

--- a/climpred/stats.py
+++ b/climpred/stats.py
@@ -250,14 +250,15 @@ def varweighted_mean_period(da, dim='time', **kwargs):
     """
     # set nans to 0
     if isinstance(da, xr.Dataset):
-        da = da[da.data_vars[0]]
+        da = da[list(da.data_vars)[0]]
         print('convert xr.Dataset to xr.DataArray.')
     da = da.fillna(0.0)
     ps = power_spectrum(da, dim=dim, **kwargs)
     # take pos freqs
     ps = ps.where(ps[f'freq_{dim}'] > 0)
     # weighted average
-    vwmp = ps.sum(f'freq_{dim}') / ((ps * ps[f'freq_{dim}']).sum(f'freq_{dim}'))
+    vwmp = ps.sum(f'freq_{dim}') / \
+        ((ps * ps[f'freq_{dim}']).sum(f'freq_{dim}'))
     del vwmp[f'freq_{dim}_spacing']
     try:
         vwmp = copy_coords_from_to(da.drop(dim), vwmp)
@@ -402,7 +403,8 @@ def dpp(ds, dim='time', m=10, chunk=True):
         c['c'] = [0]
         for i in range(1, number_chunks):
             c2 = ds.sel(
-                {dim: slice(cmin + chunk_length * i, cmin + (i + 1) * chunk_length - 1)}
+                {dim: slice(cmin + chunk_length * i, cmin
+                            + (i + 1) * chunk_length - 1)}
             )
             c2 = c2.expand_dims('c')
             c2['c'] = [i]
@@ -418,7 +420,8 @@ def dpp(ds, dim='time', m=10, chunk=True):
         # first chunk
         chunked_means = _chunking(ds, dim=dim, chunk_length=m).mean(dim)
         # sub means in chunks
-        chunked_deviations = _chunking(ds, dim=dim, chunk_length=m) - chunked_means
+        chunked_deviations = _chunking(
+            ds, dim=dim, chunk_length=m) - chunked_means
         s2v = chunked_means.var('c')
         s2e = chunked_deviations.var([dim, 'c'])
         s2 = s2v + s2e

--- a/climpred/stats.py
+++ b/climpred/stats.py
@@ -257,13 +257,12 @@ def varweighted_mean_period(da, dim='time', **kwargs):
     # take pos freqs
     ps = ps.where(ps[f'freq_{dim}'] > 0)
     # weighted average
-    vwmp = ps.sum(f'freq_{dim}') / \
-        ((ps * ps[f'freq_{dim}']).sum(f'freq_{dim}'))
+    vwmp = ps.sum(f'freq_{dim}') / ((ps * ps[f'freq_{dim}']).sum(f'freq_{dim}'))
     del vwmp[f'freq_{dim}_spacing']
     try:
         vwmp = copy_coords_from_to(da.drop(dim), vwmp)
     except ValueError:
-        print('Couldnt keep coorda.')
+        print("Couldn't keep coords.")
     return vwmp
 
 
@@ -403,8 +402,7 @@ def dpp(ds, dim='time', m=10, chunk=True):
         c['c'] = [0]
         for i in range(1, number_chunks):
             c2 = ds.sel(
-                {dim: slice(cmin + chunk_length * i, cmin
-                            + (i + 1) * chunk_length - 1)}
+                {dim: slice(cmin + chunk_length * i, cmin + (i + 1) * chunk_length - 1)}
             )
             c2 = c2.expand_dims('c')
             c2['c'] = [i]
@@ -420,8 +418,7 @@ def dpp(ds, dim='time', m=10, chunk=True):
         # first chunk
         chunked_means = _chunking(ds, dim=dim, chunk_length=m).mean(dim)
         # sub means in chunks
-        chunked_deviations = _chunking(
-            ds, dim=dim, chunk_length=m) - chunked_means
+        chunked_deviations = _chunking(ds, dim=dim, chunk_length=m) - chunked_means
         s2v = chunked_means.var('c')
         s2e = chunked_deviations.var([dim, 'c'])
         s2 = s2v + s2e

--- a/climpred/stats.py
+++ b/climpred/stats.py
@@ -255,19 +255,21 @@ def varweighted_mean_period(da, dim='time', **kwargs):
         raise ValueError('require xr.Dataset')
     da = da.fillna(0.0)
     # dim should be list
-    if type(dim) == str:
+    if isinstance(dim, str):
         dim = [dim]
     assert isinstance(dim, list)
     ps = power_spectrum(da, dim=dim, **kwargs)
-    # take pos freqs
+    # take pos
     for d in dim:
-        ps = ps.where(ps[f'freq_{d}'] > 0)
+        ps = ps.where(ps[f"freq_{d}"] > 0)
     # weighted average
     vwmp = ps
     for d in dim:
-        vwmp = vwmp.sum(f'freq_{d}') / ((vwmp * vwmp[f'freq_{d}']).sum(f'freq_{d}'))
+        vwmp = vwmp.sum(f'freq_{d}') / \
+            ((vwmp * vwmp[f'freq_{d}']).sum(f'freq_{d}'))
     for d in dim:
         del vwmp[f'freq_{d}_spacing']
+    # try to copy coords
     try:
         vwmp = copy_coords_from_to(da.drop(dim), vwmp)
     except ValueError:
@@ -335,7 +337,9 @@ def decorrelation_time(da, r=20, dim='time'):
           p.373
 
     """
-    return (da.isel(time=0, drop=True) / da.isel(time=0, drop=True)) + 2 * xr.concat(
+    one = xr.ones_like(da.isel({dim: 0}))
+    one = one.where(da.isel({dim: 0}).notnull())
+    return one + 2 * xr.concat(
         [autocorr(da, dim=dim, lag=i) ** i for i in range(1, r)], 'it'
     ).sum('it')
 
@@ -411,7 +415,8 @@ def dpp(ds, dim='time', m=10, chunk=True):
         c['c'] = [0]
         for i in range(1, number_chunks):
             c2 = ds.sel(
-                {dim: slice(cmin + chunk_length * i, cmin + (i + 1) * chunk_length - 1)}
+                {dim: slice(cmin + chunk_length * i, cmin +
+                            (i + 1) * chunk_length - 1)}
             )
             c2 = c2.expand_dims('c')
             c2['c'] = [i]
@@ -427,7 +432,8 @@ def dpp(ds, dim='time', m=10, chunk=True):
         # first chunk
         chunked_means = _chunking(ds, dim=dim, chunk_length=m).mean(dim)
         # sub means in chunks
-        chunked_deviations = _chunking(ds, dim=dim, chunk_length=m) - chunked_means
+        chunked_deviations = _chunking(
+            ds, dim=dim, chunk_length=m) - chunked_means
         s2v = chunked_means.var('c')
         s2e = chunked_deviations.var([dim, 'c'])
         s2 = s2v + s2e

--- a/climpred/stats.py
+++ b/climpred/stats.py
@@ -261,12 +261,11 @@ def varweighted_mean_period(da, dim='time', **kwargs):
     ps = power_spectrum(da, dim=dim, **kwargs)
     # take pos
     for d in dim:
-        ps = ps.where(ps[f"freq_{d}"] > 0)
+        ps = ps.where(ps[f'freq_{d}'] > 0)
     # weighted average
     vwmp = ps
     for d in dim:
-        vwmp = vwmp.sum(f'freq_{d}') / \
-            ((vwmp * vwmp[f'freq_{d}']).sum(f'freq_{d}'))
+        vwmp = vwmp.sum(f'freq_{d}') / ((vwmp * vwmp[f'freq_{d}']).sum(f'freq_{d}'))
     for d in dim:
         del vwmp[f'freq_{d}_spacing']
     # try to copy coords
@@ -415,8 +414,7 @@ def dpp(ds, dim='time', m=10, chunk=True):
         c['c'] = [0]
         for i in range(1, number_chunks):
             c2 = ds.sel(
-                {dim: slice(cmin + chunk_length * i, cmin +
-                            (i + 1) * chunk_length - 1)}
+                {dim: slice(cmin + chunk_length * i, cmin + (i + 1) * chunk_length - 1)}
             )
             c2 = c2.expand_dims('c')
             c2['c'] = [i]
@@ -432,8 +430,7 @@ def dpp(ds, dim='time', m=10, chunk=True):
         # first chunk
         chunked_means = _chunking(ds, dim=dim, chunk_length=m).mean(dim)
         # sub means in chunks
-        chunked_deviations = _chunking(
-            ds, dim=dim, chunk_length=m) - chunked_means
+        chunked_deviations = _chunking(ds, dim=dim, chunk_length=m) - chunked_means
         s2v = chunked_means.var('c')
         s2e = chunked_deviations.var([dim, 'c'])
         s2 = s2v + s2e

--- a/climpred/stats.py
+++ b/climpred/stats.py
@@ -252,12 +252,14 @@ def varweighted_mean_period(da, dim='time', **kwargs):
     if isinstance(da, xr.Dataset):
         da = da[list(da.data_vars)[0]]
         print('convert xr.Dataset to xr.DataArray.')
+    dim = [dim] if isinstance(dim, 'str') else dim
     da = da.fillna(0.0)
     ps = power_spectrum(da, dim=dim, **kwargs)
     # take pos freqs
     ps = ps.where(ps[f'freq_{dim}'] > 0)
     # weighted average
-    vwmp = ps.sum(f'freq_{dim}') / ((ps * ps[f'freq_{dim}']).sum(f'freq_{dim}'))
+    vwmp = ps.sum(f'freq_{dim}') / \
+        ((ps * ps[f'freq_{dim}']).sum(f'freq_{dim}'))
     del vwmp[f'freq_{dim}_spacing']
     try:
         vwmp = copy_coords_from_to(da.drop(dim), vwmp)
@@ -402,7 +404,8 @@ def dpp(ds, dim='time', m=10, chunk=True):
         c['c'] = [0]
         for i in range(1, number_chunks):
             c2 = ds.sel(
-                {dim: slice(cmin + chunk_length * i, cmin + (i + 1) * chunk_length - 1)}
+                {dim: slice(cmin + chunk_length * i, cmin
+                            + (i + 1) * chunk_length - 1)}
             )
             c2 = c2.expand_dims('c')
             c2['c'] = [i]
@@ -418,7 +421,8 @@ def dpp(ds, dim='time', m=10, chunk=True):
         # first chunk
         chunked_means = _chunking(ds, dim=dim, chunk_length=m).mean(dim)
         # sub means in chunks
-        chunked_deviations = _chunking(ds, dim=dim, chunk_length=m) - chunked_means
+        chunked_deviations = _chunking(
+            ds, dim=dim, chunk_length=m) - chunked_means
         s2v = chunked_means.var('c')
         s2e = chunked_deviations.var([dim, 'c'])
         s2 = s2v + s2e

--- a/climpred/stats.py
+++ b/climpred/stats.py
@@ -252,7 +252,7 @@ def varweighted_mean_period(da, dim='time', **kwargs):
     if isinstance(da, xr.Dataset):
         da = da[list(da.data_vars)[0]]
         print('convert xr.Dataset to xr.DataArray.')
-    dim = [dim] if isinstance(dim, 'str') else dim
+    dim = dim if isinstance(dim, list) else [dim]
     da = da.fillna(0.0)
     ps = power_spectrum(da, dim=dim, **kwargs)
     # take pos freqs

--- a/climpred/stats.py
+++ b/climpred/stats.py
@@ -8,6 +8,7 @@ from xrft import power_spectrum
 from xskillscore import pearson_r, pearson_r_p_value
 
 from .checks import has_dims, is_xarray
+from .utils import copy_coords_from_to
 
 
 # ----------------------------------#
@@ -254,7 +255,9 @@ def varweighted_mean_period(ds, dim='time', **kwargs):
     # weighted average
     vwmp = ps.sum(f'freq_{dim}') / ((ps * ps[f'freq_{dim}']).sum(f'freq_{dim}'))
     del vwmp[f'freq_{dim}_spacing']
-    vwmp = vwmp.assign_coords(ds.drop(dim).coords)
+    print(vwmp.coords)
+    print(ds.drop(dim).coords)
+    vwmp = copy_coords_from_to(ds.drop(dim), vwmp)
     return vwmp
 
 
@@ -318,8 +321,7 @@ def decorrelation_time(da, r=20, dim='time'):
           p.373
 
     """
-    one = da.mean(dim) / da.mean(dim)
-    return one + 2 * xr.concat(
+    return xr.full_like(da.isel({dim: 0}, drop=True), 1.0) + 2 * xr.concat(
         [autocorr(da, dim=dim, lag=i) ** i for i in range(1, r)], 'it'
     ).sum('it')
 

--- a/climpred/stats.py
+++ b/climpred/stats.py
@@ -1,4 +1,6 @@
 """Objects dealing with timeseries and ensemble statistics."""
+import warnings
+
 import numpy as np
 import numpy.polynomial.polynomial as poly
 import scipy.stats as ss
@@ -254,9 +256,7 @@ def varweighted_mean_period(da, dim='time', **kwargs):
     da = da.fillna(0.0)
     # dim should be list
     if type(dim) == str:
-        print('change dim from str to [str]')
         dim = [dim]
-    print('inside vwmp', dim, type(dim))
     assert isinstance(dim, list)
     ps = power_spectrum(da, dim=dim, **kwargs)
     # take pos freqs
@@ -271,7 +271,7 @@ def varweighted_mean_period(da, dim='time', **kwargs):
     try:
         vwmp = copy_coords_from_to(da.drop(dim), vwmp)
     except ValueError:
-        print("Couldn't keep coords.")
+        warnings.warn("Couldn't keep coords.")
     return vwmp
 
 

--- a/climpred/tests/test_hindcast_prediction.py
+++ b/climpred/tests/test_hindcast_prediction.py
@@ -1,7 +1,12 @@
+import dask
 import numpy as np
 import pytest
 from climpred.bootstrap import bootstrap_hindcast
-from climpred.constants import DETERMINISTIC_HINDCAST_METRICS, HINDCAST_COMPARISONS
+from climpred.constants import (
+    CLIMPRED_DIMS,
+    DETERMINISTIC_HINDCAST_METRICS,
+    HINDCAST_COMPARISONS,
+)
 from climpred.prediction import (
     compute_hindcast,
     compute_persistence,
@@ -79,6 +84,22 @@ def uninitialized_da():
     da = load_dataset('CESM-LE')['SST']
     # add member coordinate
     da['member'] = np.arange(1, 1 + da.member.size)
+    da = da - da.mean('time')
+    return da
+
+
+@pytest.fixture
+def hind_3d():
+    da = load_dataset('CESM-DP-SST-3D')['SST'].isel(
+        nlon=slice(0, 10), nlat=slice(0, 12)
+    )
+    da = da - da.mean('init')
+    return da
+
+
+@pytest.fixture
+def fosi_3d():
+    da = load_dataset('FOSI-SST-3D')['SST'].isel(nlon=slice(0, 10), nlat=slice(0, 12))
     da = da - da.mean('time')
     return da
 
@@ -213,3 +234,39 @@ def test_compute_hindcast_comparison_keyerrors(
             initialized_ds, reconstruction_ds, comparison=comparison, metric='mse'
         )
     assert 'Specify comparison from' in str(excinfo.value)
+
+
+@pytest.mark.parametrize('metric', ('rmse', 'pearson_r'))
+def test_compute_hindcast_dask_spatial(hind_3d, fosi_3d, metric):
+    """Chunking along spatial dims."""
+    # chunk over dims in both
+    for dim in hind_3d.dims:
+        if dim in fosi_3d.dims:
+            step = 5
+            res_chunked = compute_hindcast(
+                hind_3d.chunk({dim: step}),
+                fosi_3d.chunk({dim: step}),
+                comparison='e2r',
+                metric=metric,
+            )
+            # check for chunks
+            assert dask.is_dask_collection(res_chunked)
+            assert res_chunked.chunks is not None
+
+
+@pytest.mark.skip(reason='not yet implemented')
+@pytest.mark.parametrize('metric', ('rmse', 'pearson_r'))
+def test_compute_hindcast_dask_climpred_dims(hind_3d, fosi_3d, metric):
+    """Chunking along climpred dims if available."""
+    step = 5
+    for dim in CLIMPRED_DIMS:
+        if dim in hind_3d.dims:
+            hind_3d = hind_3d.chunk({dim: step})
+        if dim in fosi_3d.dims:
+            fosi_3d = fosi_3d.chunk({dim: step})
+        res_chunked = compute_hindcast(
+            hind_3d, fosi_3d, comparison='e2r', metric=metric
+        )
+        # check for chunks
+        assert dask.is_dask_collection(res_chunked)
+        assert res_chunked.chunks is not None

--- a/climpred/tests/test_hindcast_prediction.py
+++ b/climpred/tests/test_hindcast_prediction.py
@@ -270,3 +270,10 @@ def test_compute_hindcast_dask_climpred_dims(hind_3d, fosi_3d, metric):
         # check for chunks
         assert dask.is_dask_collection(res_chunked)
         assert res_chunked.chunks is not None
+
+
+def test_compute_hindcast_CESM_3D_keep_coords(hind_3d, fosi_3d):
+    """Test that no coords are lost in compute_hindcast with the CESM sample data."""
+    s = compute_hindcast(hind_3d, fosi_3d)
+    for c in hind_3d.drop('init').coords:
+        assert c in s.coords

--- a/climpred/tests/test_perfect_model_prediction.py
+++ b/climpred/tests/test_perfect_model_prediction.py
@@ -1,6 +1,7 @@
+import dask
 import pytest
 from climpred.bootstrap import bootstrap_perfect_model
-from climpred.constants import DETERMINISTIC_PM_METRICS
+from climpred.constants import CLIMPRED_DIMS, DETERMINISTIC_PM_METRICS
 from climpred.prediction import compute_perfect_model, compute_persistence
 from climpred.tutorial import load_dataset
 
@@ -45,6 +46,20 @@ def pm_ds_ds1d():
 @pytest.fixture
 def pm_ds_control1d():
     ds = load_dataset('MPI-control-1D').isel(area=1, period=-1)
+    return ds
+
+
+@pytest.fixture
+def ds_3d_NA():
+    """ds North Atlantic"""
+    ds = load_dataset('MPI-PM-DP-3D')['tos'].sel(x=slice(120, 130), y=slice(50, 60))
+    return ds
+
+
+@pytest.fixture
+def control_3d_NA():
+    """control North Atlantic"""
+    ds = load_dataset('MPI-control-3D')['tos'].sel(x=slice(120, 130), y=slice(50, 60))
     return ds
 
 
@@ -188,3 +203,40 @@ def test_compute_perfect_model_comparison_keyerrors(
             pm_da_ds1d, pm_da_control1d, comparison=comparison, metric='mse'
         )
     assert 'Specify comparison from' in str(excinfo.value)
+
+
+@pytest.mark.parametrize('metric', ('rmse', 'pearson_r'))
+@pytest.mark.parametrize('comparison', PM_COMPARISONS)
+def test_compute_pm_dask_spatial(ds_3d_NA, control_3d_NA, comparison, metric):
+    """Chunking along spatial dims."""
+    # chunk over dims in both
+    for dim in ds_3d_NA.dims:
+        if dim in control_3d_NA.dims:
+            step = 5
+            res_chunked = compute_perfect_model(
+                ds_3d_NA.chunk({dim: step}),
+                control_3d_NA.chunk({dim: step}),
+                comparison=comparison,
+                metric=metric,
+            )
+            # check for chunks
+            assert dask.is_dask_collection(res_chunked)
+            assert res_chunked.chunks is not None
+
+
+@pytest.mark.parametrize('metric', ('rmse', 'pearson_r', 'crps'))
+@pytest.mark.parametrize('comparison', PM_COMPARISONS)
+def test_compute_pm_dask_climpred_dims(ds_3d_NA, control_3d_NA, comparison, metric):
+    """Chunking along climpred dims if available."""
+    step = 5
+    for dim in CLIMPRED_DIMS:
+        if dim in ds_3d_NA.dims:
+            ds_3d_NA = ds_3d_NA.chunk({dim: step})
+        if dim in control_3d_NA.dims:
+            control_3d_NA = control_3d_NA.chunk({dim: step})
+        res_chunked = compute_perfect_model(
+            ds_3d_NA, control_3d_NA, comparison=comparison, metric=metric
+        )
+        # check for chunks
+        assert dask.is_dask_collection(res_chunked)
+        assert res_chunked.chunks is not None

--- a/climpred/tests/test_perfect_model_prediction.py
+++ b/climpred/tests/test_perfect_model_prediction.py
@@ -224,7 +224,7 @@ def test_compute_pm_dask_spatial(ds_3d_NA, control_3d_NA, comparison, metric):
             assert res_chunked.chunks is not None
 
 
-@pytest.mark.parametrize('metric', ('rmse', 'pearson_r', 'crps'))
+@pytest.mark.parametrize('metric', ('rmse', 'pearson_r'))
 @pytest.mark.parametrize('comparison', PM_COMPARISONS)
 def test_compute_pm_dask_climpred_dims(ds_3d_NA, control_3d_NA, comparison, metric):
     """Chunking along climpred dims if available."""

--- a/climpred/tests/test_stats.py
+++ b/climpred/tests/test_stats.py
@@ -4,14 +4,8 @@ import pytest
 import xarray as xr
 from climpred.bootstrap import dpp_threshold, varweighted_mean_period_threshold
 from climpred.exceptions import DimensionError
-from climpred.stats import (
-    autocorr,
-    corr,
-    decorrelation_time,
-    dpp,
-    rm_trend,
-    varweighted_mean_period,
-)
+from climpred.stats import (autocorr, corr, decorrelation_time, dpp, rm_trend,
+                            varweighted_mean_period)
 from climpred.tutorial import load_dataset
 from scipy.signal import correlate
 from xarray.testing import assert_allclose
@@ -43,7 +37,8 @@ def multi_dim_ds():
 @pytest.fixture
 def control_3d_NA():
     """North Atlantic"""
-    ds = load_dataset('MPI-control-3D')['tos'].isel(x=slice(130, 136), y=slice(30, 36))
+    ds = load_dataset(
+        'MPI-control-3D')['tos'].isel(x=slice(110, 120), y=slice(50, 60))
     return ds
 
 
@@ -127,6 +122,7 @@ def test_dpp(control_3d_NA, chunk):
 def test_potential_predictability_likely(control_3d_NA, func):
     """Check for positive diagnostic potential predictability in NA SST."""
     control = control_3d_NA
+    print(control.dims)
     res = func(control)
     assert res.mean() > 0
 

--- a/climpred/tests/test_stats.py
+++ b/climpred/tests/test_stats.py
@@ -4,8 +4,14 @@ import pytest
 import xarray as xr
 from climpred.bootstrap import dpp_threshold, varweighted_mean_period_threshold
 from climpred.exceptions import DimensionError
-from climpred.stats import (autocorr, corr, decorrelation_time, dpp, rm_trend,
-                            varweighted_mean_period)
+from climpred.stats import (
+    autocorr,
+    corr,
+    decorrelation_time,
+    dpp,
+    rm_trend,
+    varweighted_mean_period,
+)
 from climpred.tutorial import load_dataset
 from scipy.signal import correlate
 from xarray.testing import assert_allclose
@@ -37,8 +43,7 @@ def multi_dim_ds():
 @pytest.fixture
 def control_3d_NA():
     """North Atlantic"""
-    ds = load_dataset(
-        'MPI-control-3D')['tos'].isel(x=slice(110, 120), y=slice(50, 60))
+    ds = load_dataset('MPI-control-3D')['tos'].isel(x=slice(110, 120), y=slice(50, 60))
     return ds
 
 

--- a/climpred/tests/test_stats.py
+++ b/climpred/tests/test_stats.py
@@ -181,7 +181,7 @@ def test_bootstrap_func_multiple_sig_levels(control_3d_NA):
 # @pytest.mark.parametrize(
 #    'func', (dpp, varweighted_mean_period, decorrelation_time, autocorr)
 # )
-@pytest.mark.parametrize('func', (dpp, autocorr))
+@pytest.mark.parametrize('func', (dpp, autocorr, varweighted_mean_period))
 def test_stats_functions_dask_single_chunk(control_3d_NA, func):
     """Test stats functions when single chunk not along dim."""
     step = -1  # single chunk
@@ -189,13 +189,6 @@ def test_stats_functions_dask_single_chunk(control_3d_NA, func):
         control_chunked = control_3d_NA.chunk({chunk_dim: step})
         for dim in control_3d_NA.dims:
             if dim != chunk_dim:
-                print(
-                    control_3d_NA.coords,
-                    control_chunked.coords,
-                    dim,
-                    chunk_dim,
-                    func.__name__,
-                )
                 res_chunked = func(control_chunked, dim=dim)
                 res = func(control_3d_NA, dim=dim)
                 # check for chunks
@@ -209,15 +202,15 @@ def test_stats_functions_dask_single_chunk(control_3d_NA, func):
 
 
 # @pytest.mark.skip(reason='dask doesnt work yet on all stats funcs')
-# @pytest.mark.parametrize('func', [dpp, autocorr, varweighted_mean_period, decorrelation_time])
-@pytest.mark.parametrize('func', [dpp, autocorr])
+# @pytest.mark.parametrize('func',
+#   [dpp, autocorr, varweighted_mean_period, decorrelation_time])
+@pytest.mark.parametrize('func', [dpp, autocorr, varweighted_mean_period])
 def test_stats_functions_dask_many_chunks(control_3d_NA, func):
-    """Check whether selected stats functions be chunked in multiple chunks and computed along other dim."""
+    """Check whether selected stats functions be chunked in multiple chunks and
+     computed along other dim."""
     step = 1
-    print(control_3d_NA.shape)
     for chunk_dim in control_3d_NA.dims:
         control_chunked = control_3d_NA.chunk({chunk_dim: step})
-        print(control_chunked.chunks)
         for dim in control_3d_NA.dims:
             if dim != chunk_dim and dim in control_chunked.dims:
                 res_chunked = func(control_chunked, dim=dim)

--- a/climpred/tests/test_stats.py
+++ b/climpred/tests/test_stats.py
@@ -225,3 +225,12 @@ def test_stats_functions_dask_many_chunks(control_3d_NA, func):
 
                 # check for identical result
                 assert_allclose(res, res_chunked.compute())
+
+
+def test_varweighted_mean_period(control_3d_NA):
+    for d in control_3d_NA.dims:
+        print(d, type(d))
+        varweighted_mean_period(control_3d_NA, dim=d)
+        di = [di for di in control_3d_NA.dims if di != d]
+        print(di)
+        varweighted_mean_period(control_3d_NA, dim=di)

--- a/climpred/tests/test_stats.py
+++ b/climpred/tests/test_stats.py
@@ -204,7 +204,7 @@ def test_stats_functions_dask_single_chunk(control_3d_NA, func):
 
 # @pytest.mark.skip(reason='dask doesnt work yet on all stats funcs')
 # @pytest.mark.parametrize('func',
-#   [dpp, autocorr, varweighted_mean_period, decorrelation_time])
+#    [dpp, autocorr, varweighted_mean_period, decorrelation_time])
 @pytest.mark.parametrize('func', [dpp, autocorr, varweighted_mean_period])
 def test_stats_functions_dask_many_chunks(control_3d_NA, func):
     """Check whether selected stats functions be chunked in multiple chunks and
@@ -222,15 +222,15 @@ def test_stats_functions_dask_many_chunks(control_3d_NA, func):
                 # check for no chunks
                 assert not dask.is_dask_collection(res)
                 assert res.chunks is None
-
                 # check for identical result
                 assert_allclose(res, res_chunked.compute())
 
 
-def test_varweighted_mean_period(control_3d_NA):
+def test_varweighted_mean_period_dim(control_3d_NA):
+    """Test varweighted_mean_period for different dims."""
     for d in control_3d_NA.dims:
-        print(d, type(d))
+        # single dim
         varweighted_mean_period(control_3d_NA, dim=d)
+        # all but one dim
         di = [di for di in control_3d_NA.dims if di != d]
-        print(di)
         varweighted_mean_period(control_3d_NA, dim=di)

--- a/climpred/tests/test_utils.py
+++ b/climpred/tests/test_utils.py
@@ -6,8 +6,12 @@ from climpred.constants import DETERMINISTIC_PM_METRICS, PM_COMPARISONS
 from climpred.metrics import _pearson_r
 from climpred.prediction import compute_hindcast, compute_perfect_model
 from climpred.tutorial import load_dataset
-from climpred.utils import (copy_coords_from_to, get_comparison_function,
-                            get_metric_function, intersect)
+from climpred.utils import (
+    copy_coords_from_to,
+    get_comparison_function,
+    get_metric_function,
+    intersect,
+)
 
 
 @pytest.fixture
@@ -20,8 +24,7 @@ def control_ds_3d():
 @pytest.fixture
 def control_da_3d():
     """North Atlantic xr.DataArray."""
-    da = load_dataset('MPI-control-3D').sel(x=slice(120, 130),
-                                            y=slice(50, 60))['tos']
+    da = load_dataset('MPI-control-3D').sel(x=slice(120, 130), y=slice(50, 60))['tos']
     return da
 
 
@@ -114,8 +117,7 @@ def test_bootstrap_pm_assign_attrs():
     assert actual['metric'] == metric
     assert actual['comparison'] == comparison
     assert actual['bootstrap_iterations'] == bootstrap
-    assert str(round((1 - sig / 100) / 2, 3)
-               ) in actual['confidence_interval_levels']
+    assert str(round((1 - sig / 100) / 2, 3)) in actual['confidence_interval_levels']
     if metric == 'pearson_r':
         assert actual['units'] == 'None'
     assert 'bootstrap' in actual['skill_calculated_by_function']
@@ -127,8 +129,7 @@ def test_hindcast_assign_attrs():
     comparison = 'e2r'
     da = load_dataset('CESM-DP-SST')
     control = load_dataset('ERSST')
-    actual = compute_hindcast(
-        da, control, metric=metric, comparison=comparison).attrs
+    actual = compute_hindcast(da, control, metric=metric, comparison=comparison).attrs
     assert actual['metric'] == metric
     assert actual['comparison'] == comparison
     if metric == 'pearson_r':

--- a/climpred/tests/test_utils.py
+++ b/climpred/tests/test_utils.py
@@ -141,7 +141,7 @@ def test_copy_coords_from_to_ds(control_ds_3d):
     #
     xro = control_ds_3d
     c_1time = xro.isel(time=4).drop('time')
-    assert not 'time' in c_1time.coords
+    assert 'time' not in c_1time.coords
     c_1time = copy_coords_from_to(xro.isel(time=2), c_1time)
     assert (c_1time.time == xro.isel(time=2).time).all()
 
@@ -151,7 +151,7 @@ def test_copy_coords_from_to_da(control_da_3d):
     #
     xro = control_da_3d
     c_1time = xro.isel(time=4).drop('time')
-    assert not 'time' in c_1time.coords
+    assert 'time' not in c_1time.coords
     c_1time = copy_coords_from_to(xro.isel(time=2), c_1time)
     assert (c_1time.time == xro.isel(time=2).time).all()
 
@@ -161,7 +161,7 @@ def test_copy_coords_from_to_ds_chunk(control_ds_3d):
     #
     xro = control_ds_3d.chunk({'time': 5})
     c_1time = xro.isel(time=4).drop('time')
-    assert not 'time' in c_1time.coords
+    assert 'time' not in c_1time.coords
     c_1time = copy_coords_from_to(xro.isel(time=2), c_1time)
     assert (c_1time.time == xro.isel(time=2).time).all()
 
@@ -171,6 +171,6 @@ def test_copy_coords_from_to_da_chunk(control_da_3d):
     #
     xro = control_da_3d.chunk({'time': 5})
     c_1time = xro.isel(time=4).drop('time')
-    assert not 'time' in c_1time.coords
+    assert 'time' not in c_1time.coords
     c_1time = copy_coords_from_to(xro.isel(time=2), c_1time)
     assert (c_1time.time == xro.isel(time=2).time).all()

--- a/climpred/tests/test_utils.py
+++ b/climpred/tests/test_utils.py
@@ -6,12 +6,8 @@ from climpred.constants import DETERMINISTIC_PM_METRICS, PM_COMPARISONS
 from climpred.metrics import _pearson_r
 from climpred.prediction import compute_hindcast, compute_perfect_model
 from climpred.tutorial import load_dataset
-from climpred.utils import (
-    copy_coords_from_to,
-    get_comparison_function,
-    get_metric_function,
-    intersect,
-)
+from climpred.utils import (copy_coords_from_to, get_comparison_function,
+                            get_metric_function, intersect)
 
 
 @pytest.fixture
@@ -24,7 +20,8 @@ def control_ds_3d():
 @pytest.fixture
 def control_da_3d():
     """North Atlantic xr.DataArray."""
-    da = load_dataset('MPI-control-3D').sel(x=slice(120, 130), y=slice(50, 60))['tos']
+    da = load_dataset('MPI-control-3D').sel(x=slice(120, 130),
+                                            y=slice(50, 60))['tos']
     return da
 
 
@@ -117,7 +114,8 @@ def test_bootstrap_pm_assign_attrs():
     assert actual['metric'] == metric
     assert actual['comparison'] == comparison
     assert actual['bootstrap_iterations'] == bootstrap
-    assert str(round((1 - sig / 100) / 2, 3)) in actual['confidence_interval_levels']
+    assert str(round((1 - sig / 100) / 2, 3)
+               ) in actual['confidence_interval_levels']
     if metric == 'pearson_r':
         assert actual['units'] == 'None'
     assert 'bootstrap' in actual['skill_calculated_by_function']
@@ -129,7 +127,8 @@ def test_hindcast_assign_attrs():
     comparison = 'e2r'
     da = load_dataset('CESM-DP-SST')
     control = load_dataset('ERSST')
-    actual = compute_hindcast(da, control, metric=metric, comparison=comparison).attrs
+    actual = compute_hindcast(
+        da, control, metric=metric, comparison=comparison).attrs
     assert actual['metric'] == metric
     assert actual['comparison'] == comparison
     if metric == 'pearson_r':

--- a/climpred/tests/test_versioning.py
+++ b/climpred/tests/test_versioning.py
@@ -1,0 +1,5 @@
+from climpred.versioning.print_versions import show_versions
+
+
+def test_show_versions():
+    show_versions()

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -172,3 +172,18 @@ def assign_attrs(
         'created'
     ] = f'{datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S%f")[:-6]}'
     return skill
+
+
+def copy_coords_from_to(xro_from, xro_to):
+    """Copy coords from one xr object to another."""
+    if isinstance(xro_from, xr.DataArray) and isinstance(xro_to, xr.DataArray):
+        for c in xro_from.coords:
+            xro_to[c] = xro_from[c]
+        return xro_to
+    elif isinstance(xro_from, xr.Dataset) and isinstance(xro_to, xr.Dataset):
+        xro_to = xro_to.assign_coords(**xro_from.coords)
+    else:
+        raise ValueError(
+            f'xro_from and xro_to must be both either xr.DataArray or xr.Dataset, found {type(xro_from)} {type(xro_to)}.'
+        )
+    return xro_to

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -184,6 +184,7 @@ def copy_coords_from_to(xro_from, xro_to):
         xro_to = xro_to.assign_coords(**xro_from.coords)
     else:
         raise ValueError(
-            f'xro_from and xro_to must be both either xr.DataArray or xr.Dataset, found {type(xro_from)} {type(xro_to)}.'
+            f'xro_from and xro_to must be both either xr.DataArray or',
+            f'xr.Dataset, found {type(xro_from)} {type(xro_to)}.',
         )
     return xro_to

--- a/docs/source/examples/tropical-pacific-ssts.ipynb
+++ b/docs/source/examples/tropical-pacific-ssts.ipynb
@@ -273,12 +273,12 @@
       "<xarray.Dataset>\n",
       "Dimensions:  (lead: 10, nlat: 37, nlon: 26)\n",
       "Coordinates:\n",
+      "    TLONG    (lead, nlat, nlon) float64 250.8 251.9 253.1 ... 276.7 277.8 278.9\n",
+      "    TAREA    (lead, nlat, nlon) float64 3.661e+13 3.661e+13 ... 3.714e+13\n",
       "  * nlat     (nlat) int64 0 1 2 3 4 5 6 7 8 9 ... 27 28 29 30 31 32 33 34 35 36\n",
       "  * nlon     (nlon) int64 0 1 2 3 4 5 6 7 8 9 ... 16 17 18 19 20 21 22 23 24 25\n",
-      "    TLONG    (nlat, nlon) float64 250.8 251.9 253.1 254.2 ... 276.7 277.8 278.9\n",
-      "    TAREA    (nlat, nlon) float64 3.661e+13 3.661e+13 ... 3.714e+13 3.714e+13\n",
       "  * lead     (lead) int64 1 2 3 4 5 6 7 8 9 10\n",
-      "    TLAT     (nlat, nlon) float64 -9.75 -9.75 -9.75 ... -0.1336 -0.1336 -0.1336\n",
+      "    TLAT     (lead, nlat, nlon) float64 -9.75 -9.75 -9.75 ... -0.1336 -0.1336\n",
       "Data variables:\n",
       "    SST      (lead, nlat, nlon) float32 0.54588705 0.53977644 ... 0.088374\n",
       "Attributes:\n",
@@ -288,16 +288,12 @@
       "    metric:                        pearson_r\n",
       "    comparison:                    e2r\n",
       "    units:                         None\n",
-      "    created:                       2019-10-23 14:14:03\n"
+      "    created:                       2019-11-14 21:52:34\n"
      ]
     }
    ],
    "source": [
     "predictability = hindcast.compute_metric(metric='acc')\n",
-    "# `compute_metric` dropped the TLAT coordinate for some reason. This will\n",
-    "# be fixed in a later version of `climpred`.\n",
-    "predictability['TLAT'] = recon['TLAT']\n",
-    "predictability = predictability.set_coords('TLAT')\n",
     "print(predictability)"
    ]
   },
@@ -315,11 +311,6 @@
    "outputs": [],
    "source": [
     "significance = hindcast.compute_metric(metric='pval')\n",
-    "\n",
-    "# `compute_metric` dropped the TLAT coordinate for some reason. This will\n",
-    "# be fixed in a later version of `climpred`.\n",
-    "significance['TLAT'] = recon['TLAT']\n",
-    "significance = significance.set_coords('TLAT')\n",
     "\n",
     "# Mask latitude and longitude by significance for stippling.\n",
     "siglat = significance.TLAT.where(significance.SST <= 0.05)\n",
@@ -385,9 +376,7 @@
    },
    "outputs": [],
    "source": [
-    "rmse = hindcast.compute_metric(metric='rmse')\n",
-    "rmse['TLAT'] = recon['TLAT']\n",
-    "rmse = rmse.set_coords('TLAT')"
+    "rmse = hindcast.compute_metric(metric='rmse')"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ xskillscore>=0.0.5
 eofs
 matplotlib
 tqdm
+xrft

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,10 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 line_length = 88
+
+[tool:pytest]
+python_files=test_*.py
+testpaths=climpred/tests
+
+[aliases]
+test = pytest


### PR DESCRIPTION
# Description

with CMIP6 we will handle quite large datasets. chunking with `dask` will faciliate this. However, we didn't test our `compute_x` and `stats` functions for this yet. Chunking across spatial dims always works out of the box. To be implemented is support for `compute_hindcast` with inputs chunked along `CLIMPRED_DIMS`. This could be connected to https://github.com/bradyrx/climpred/issues/237

Added:
- test compute_x dask
- test stats dask (skipped right now for `decorrelation_time`)
- tqdm.auto
- keep coords in `compute_hindcast`

Reworked:
- `var_weighted_mean_period`: now takes power_spectrum from `xrft`. much more powerful and no new base dependencies (`xrft` relies on what we use anyways). and now `dim` instead of `time_dim`. coords kept.
- `ddp`: dim='time'


Fixes # https://github.com/bradyrx/climpred/issues/208 partly for `vwmp` and https://github.com/bradyrx/climpred/issues/208
https://github.com/bradyrx/climpred/issues/249 

## Type of change

Please delete options that are not relevant.

-   [x]  Bug fix (non-breaking change which fixes an issue)
-   [x]  New feature (non-breaking change which adds functionality)
-   [x]  Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here.

## Checklist (while developing)

-   [x]  I have added docstrings to all new functions.
-   [x]  I have commented my code, particularly in hard-to-understand areas
-   [x]  Tests added for `pytest`, if necessary.

## Pre-Merge Checklist (final steps)

-   [x]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [x]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

I will continue this PR on sunday. 