### PR TITLE
add toolz to docs requirement

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,4 @@ xarray
 jupyterlab
 netcdf4
 tqdm
+toolz


### PR DESCRIPTION
Adds `toolz` to the docs requirement. The main `readthedocs` broke due to not having this for some reason...

I got `climpred` signed up for beta testing to have `readthedocs` run on PRs. So I'm going to leave this open to see if it builds on the PR.