### PR TITLE
Update xskillscore version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,7 @@ venv.bak/
 # mypy
 .mypy_cache/
 
+# VS Code
+.vscode/
+
 # End of https://www.gitignore.io/api/python

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,6 @@ Depreciated
 -----------
 - Abbreviation `pval` depreciated. Use `p_pval` for `pearson_r_p_value` instead. (:pr:`264`) `Aaron Spring`_.
 
-
 Features
 --------
 - `metric_kwargs` are passed to `xs.metric`. (:pr:`264`) `Aaron Spring`_.
@@ -23,6 +22,7 @@ Bug Fixes
 ---------
 - Add `skill` from `compute_hindcast` keeps coords of `hindcast` (:pr:`258`) `Aaron Spring`_.
 - metric `uacc` does not crash when `ppp` negative. (:pr:`264`) `Aaron Spring`_.
+- Update `xskillscore` to version 0.0.9 to fix all-NaN issue with `pearson_r` and `pearson_r_p_value` when there's missing data. (:pr:`269`) `Riley X. Brady`_.
 
 Internals/Minor Fixes
 ---------------------
@@ -30,7 +30,7 @@ Internals/Minor Fixes
 - Add ``tqdm`` progress bar to ``bootstrap_compute`` (:pr:`244`) `Aaron Spring`_.
 - Remove inplace behavior for ``HindcastEnsemble`` and ``PerfectModelEnsemble`` (:pr:`243`) `Riley X. Brady`_.
 - Added tests for chunking with `dask` (:pr:`258`) `Aaron Spring`_.
-
+- Fix test issues with esmpy 8.0 by forcing esmpy 7.1 (:pr:`269`) `Riley X. Brady`_..
 
 Documentation
 -------------

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -3,32 +3,45 @@ channels:
   - conda-forge
 dependencies:
   - python=3.6
-  - numpy
-  - xarray
-  - jupyterlab
-  - dask
-  - numba
-  - scipy
-  - esmpy
-  - matplotlib
-  - bottleneck
-  - netcdf4
-  - pytest
-  - eofs
-  - lxml
+  # Documentation
+  - nbsphinx
   - sphinx_rtd_theme
   - sphinx
-  - nbsphinx
-  - cartopy
-  - pip
+  - sphinxcontrib-napoleon
+  # IDE
+  - jupyterlab
+  # Input/Output
+  - netcdf4
+  # Miscellaneous
+  - lxml
   - tqdm
+  # Numerics
+  - numpy
+  - scipy
+  - xarray
+  # Package Management
+  - asv
+  - black
+  - coveralls
+  - flake8
+  - importlib_metadata
+  - pre-commit
+  - pylint
+  - pytest
+  - pytest-cov
+  # Performance
+  - bottleneck
+  - numba
+  - dask
+  # Regridding
+  # Currently, xesmf breaks with esmpy v8.0.0. There is an issue with PIO and MPI.
+  # See e.g. https://github.com/conda-forge/esmpy-feedstock/issues/28
+  - esmpy<=7.1.0
   - xesmf
-  - pip:
-    - xskillscore>=0.0.8
-    - pytest-cov
-    - coveralls
-    - sphinxcontrib-napoleon
-    - importlib_metadata
-    - pre-commit
-    - asv
-    - xrft
+  # Statistics
+  - eofs
+  - xrft
+  - xskillscore>=0.0.9
+  # Visualization
+  - cartopy
+  - matplotlib

--- a/climpred/tests/test_hindcastEnsemble_class.py
+++ b/climpred/tests/test_hindcastEnsemble_class.py
@@ -169,7 +169,7 @@ def test_smooth_goddard(fosi_3d, dple_3d):
     dim = 'lead'
     assert actual_initialized[dim].size < initialized_before[dim].size
     for dim in ['nlon', 'nlat']:
-        assert actual_initialized[dim[1:]].size < initialized_before[dim].size
+        assert actual_initialized[dim].size < initialized_before[dim].size
 
 
 def test_smooth_coarsen(fosi_3d, dple_3d):

--- a/climpred/tests/test_hindcastEnsemble_class.py
+++ b/climpred/tests/test_hindcastEnsemble_class.py
@@ -169,7 +169,7 @@ def test_smooth_goddard(fosi_3d, dple_3d):
     dim = 'lead'
     assert actual_initialized[dim].size < initialized_before[dim].size
     for dim in ['nlon', 'nlat']:
-        assert actual_initialized[dim].size < initialized_before[dim].size
+        assert actual_initialized[dim[1:]].size < initialized_before[dim].size
 
 
 def test_smooth_coarsen(fosi_3d, dple_3d):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-numpy
-xarray
-scipy
-xskillscore>=0.0.5
 eofs
 matplotlib
+numpy
+scipy
 tqdm
+xarray
 xrft
+xskillscore>=0.0.9


### PR DESCRIPTION
# Description

Updates `xskillscore` version to 0.0.9 to deal with NaN issues in `pearson_r_p_value`.