### PR TITLE
add helpful links and publications page to docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Documentation
 - Add documentation for smoothing and compute over dimension (:pr:`244`) `Aaron Spring`_.
 - Update API to be more organized with individual function/class pages. (:pr:`243`) `Riley X. Brady`_.
 - Add page describing the ``HindcastEnsemble`` and ``PerfectModelEnsemble`` objects more clearly. (:pr:`243`) `Riley X. Brady`_.
+- Add page for publications and helpful links. (:pr:`270`) `Riley X. Brady`_.
 
 climpred v1.1.0 (2019-09-23)
 ============================

--- a/docs/source/helpful-links.rst
+++ b/docs/source/helpful-links.rst
@@ -1,0 +1,10 @@
+*************
+Helpful Links
+*************
+
+We hope to curate in the ``climpred`` documentation a comprehensive report of terminology, best practices, analysis methods, etc. in the prediction community. Here we suggest other resources for initialized prediction of the Earth system to round out the information provided in our documentation.
+
+Forecast Verification
+#####################
+
+* `CAWCR Forecast Verification Overview <https://www.cawcr.gov.au/projects/verification/>`_: A nice overview of forecast verification, including a suite of metrics and their derivation.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -94,6 +94,8 @@ You can also install the bleeding edge (pre-release versions) by cloning this re
 **Help & Reference**
 
 * :doc:`api`
+* :doc:`helpful-links`
+* :doc:`publications`
 * :doc:`contributing`
 * :doc:`changelog`
 * :doc:`release_procedure`
@@ -105,6 +107,8 @@ You can also install the bleeding edge (pre-release versions) by cloning this re
     :caption: Help & Reference
 
     api
+    helpful-links
+    publications
     contributing
     changelog
     release_procedure

--- a/docs/source/publications.rst
+++ b/docs/source/publications.rst
@@ -1,0 +1,12 @@
+*******************************
+Publications Using ``climpred``
+*******************************
+
+Below is a list of publications that have made use of ``climpred`` in their analysis. You can nod to ``climpred``, e.g., in your acknowledgements section to help build the community. The main developers of the package intend to release a manuscript documenting ``climpred`` in 2020 with a citable DOI, so this can be referenced in the future.
+
+Feel free to open a `Pull Request <contributing.html>`_ to add your publication to the list!
+
+2019
+####
+
+* Brady, R. X., Lovenduski, N. S., Yeager, S. G., Long, M. C., & Lindsay, K. (2019, October 10). Skillful multiyear predictions of ocean acidification in the California Current System. https://doi.org/10.31223/osf.io/3m2h7


### PR DESCRIPTION
# Description

Minor updates to documentation. This adds a "publications" page to place citations that used `climpred` and a "helpful links" page to curate good resources for initialized prediction analysis.

Addresses https://github.com/bradyrx/climpred/issues/254.