### PR TITLE
pytest refactor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ climpred v2.0.1 (2020-01-xx)
 Internals/Minor Fixes
 ---------------------
 - Gather all ``pytest.fixture``s in ``conftest.py``. (:pr:`313`) `Aaron Spring`_.
+- Move ``x_METRICS`` and ``COMPARISONS`` to ``metrics.py`` and ``comparisons.py`` in
+  order to avoid circular import dependencies. (:pr:`315`) `Aaron Spring`_.
 
 
 climpred v2.0.0 (2020-01-22)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 What's New
 ==========
 
+climpred v2.0.1 (2020-01-xx)
+============================
+
+Internals/Minor Fixes
+---------------------
+- Gather all ``pytest.fixture``s in ``conftest.py``. (:pr:`xxx`) `Aaron Spring`_.
+
+
 climpred v2.0.0 (2020-01-22)
 ============================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ climpred v2.0.1 (2020-01-xx)
 
 Internals/Minor Fixes
 ---------------------
-- Gather all ``pytest.fixture``s in ``conftest.py``. (:pr:`xxx`) `Aaron Spring`_.
+- Gather all ``pytest.fixture``s in ``conftest.py``. (:pr:`313`) `Aaron Spring`_.
 
 
 climpred v2.0.0 (2020-01-22)

--- a/HOWTOCONTRIBUTE.rst
+++ b/HOWTOCONTRIBUTE.rst
@@ -160,6 +160,8 @@ Preparing Pull Requests
    Check that your contribution is covered by tests and therefore increases the overall test coverage:
 
     $ coverage run --source climpred -m py.test
+    $ coverage report
+    $ coveralls
 
   Please stick to `xarray <http://xarray.pydata.org/en/stable/contributing.html>`_'s testing recommendations.
 

--- a/HOWTOCONTRIBUTE.rst
+++ b/HOWTOCONTRIBUTE.rst
@@ -155,10 +155,13 @@ Preparing Pull Requests
 
    Now running tests is as simple as issuing this command::
 
+    $ pytest climpred
+
+   Check that your contribution is covered by tests and therefore increases the overall test coverage:
+
     $ coverage run --source climpred -m py.test
 
-
-   This command will run tests via the "pytest" tool against Python 3.6.
+  Please stick to `xarray <http://xarray.pydata.org/en/stable/contributing.html>`_'s testing recommendations.
 
 
 #. Create a new changelog entry in ``CHANGELOG.rst``:

--- a/climpred/tests/conftest.py
+++ b/climpred/tests/conftest.py
@@ -1,0 +1,149 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from climpred.tutorial import load_dataset
+
+
+@pytest.fixture
+def PM_da_ds_1d():
+    """MPI Perfect-model-framework initialized timeseries xr.DataArray."""
+    return load_dataset('MPI-PM-DP-1D')['tos'].isel(area=1, period=-1)
+
+
+@pytest.fixture
+def PM_da_control_1d():
+    """To MPI Perfect-model-framework corresponding control timeseries xr.DataArray."""
+    return load_dataset('MPI-control-1D')['tos'].isel(area=1, period=-1)
+
+
+@pytest.fixture
+def hind_ds_initialized_1d():
+    """CESM-DPLE initialized hindcast timeseries mean removed xr.Dataset."""
+    da = load_dataset('CESM-DP-SST')
+    return da - da.mean('init')
+
+
+@pytest.fixture
+def hind_ds_initialized_1d_lead0(hind_ds_initialized_1d):
+    """CESM-DPLE initialized hindcast timeseries mean removed xr.Dataset in lead-0
+    framework."""
+    da = hind_ds_initialized_1d
+    # Change to a lead-0 framework
+    da['init'] += 1
+    da['lead'] -= 1
+    return da
+
+
+@pytest.fixture
+def hind_da_initialized_1d(hind_ds_initialized_1d):
+    """CESM-DPLE initialized hindcast timeseries mean removed xr.DataArray."""
+    return hind_ds_initialized_1d['SST']
+
+
+@pytest.fixture
+def hind_da_initialized_3d():
+    """CESM-DPLE initialized hindcast maps mean removed xr.DataArray."""
+    da = load_dataset('CESM-DP-SST-3D')['SST'].isel(
+        nlon=slice(0, 10), nlat=slice(0, 12)
+    )
+    da = da - da.mean('init')
+    return da
+
+
+@pytest.fixture
+def hind_ds_uninitialized_1d():
+    """CESM-LE uninitialized historical timeseries members mean removed xr.Dataset."""
+    da = load_dataset('CESM-LE')
+    # add member coordinate
+    da['member'] = range(1, 1 + da.member.size)
+    return da - da.mean('time')
+
+
+@pytest.fixture
+def hind_da_uninitialized_1d(hind_ds_uninitialized_1d):
+    """CESM-LE uninitialized historical timeseries members mean removed xr.DataArray."""
+    return hind_ds_uninitialized_1d['SST']
+
+
+@pytest.fixture
+def reconstruction_ds_1d():
+    """CESM-FOSI historical reconstruction timeseries members mean removed
+    xr.Dataset."""
+    da = load_dataset('FOSI-SST')
+    return da - da.mean('time')
+
+
+@pytest.fixture
+def reconstruction_da_1d(reconstruction_ds_1d):
+    """CESM-FOSI historical reconstruction timeseries members mean removed
+    xr.DataArray."""
+    return reconstruction_ds_1d['SST']
+
+
+@pytest.fixture
+def reconstruction_da_3d():
+    """CESM-FOSI historical reconstruction maps members mean removed
+    xr.DataArray."""
+    da = load_dataset('FOSI-SST-3D')['SST'].isel(nlon=slice(0, 10), nlat=slice(0, 12))
+    da = da - da.mean('time')
+    return da
+
+
+@pytest.fixture
+def observations_ds_1d():
+    """Historical timeseries from observations matching `hind_da_initialized_1d` and
+    `hind_da_uninitialized_1d` mean removed xr.Dataset."""
+    da = load_dataset('ERSST')
+    return da - da.mean('time')
+
+
+@pytest.fixture
+def observations_da_1d(observations_ds_1d):
+    """Historical timeseries from observations matching `hind_da_initialized_1d` and
+    `hind_da_uninitialized_1d` mean removed xr.DataArray."""
+    return observations_ds_1d['SST']
+
+
+@pytest.fixture
+def ds1():
+    """Small plain multi-dimensional coords xr.Dataset."""
+    return xr.Dataset(
+        {'air': (('lon', 'lat'), [[0, 1, 2], [3, 4, 5], [6, 7, 8]])},
+        coords={'lon': [1, 3, 4], 'lat': [5, 6, 7]},
+    )
+
+
+@pytest.fixture
+def ds2():
+    """Small plain multi-dimensional coords xr.Dataset identical values but with
+    different coords compared to ds1."""
+    return xr.Dataset(
+        {'air': (('lon', 'lat'), [[0, 1, 2], [3, 4, 5], [6, 7, 8]])},
+        coords={'lon': [1, 3, 6], 'lat': [5, 6, 9]},
+    )
+
+
+@pytest.fixture
+def da1():
+    """Small plain two-dimensional xr.DataArray."""
+    return xr.DataArray([[0, 1], [3, 4], [6, 7]], dims=('x', 'y'))
+
+
+@pytest.fixture
+def da2():
+    """Small plain two-dimensional xr.DataArray with different values compared to
+    da1."""
+    return xr.DataArray([[0, 1], [5, 6], [6, 7]], dims=('x', 'y'))
+
+
+@pytest.fixture
+def da_lead():
+    """Small xr.DataArray with coords `init` and `lead`."""
+    lead = np.arange(5)
+    init = np.arange(5)
+    return xr.DataArray(
+        np.random.rand(len(lead), len(init)),
+        dims=['init', 'lead'],
+        coords=[init, lead],
+    )

--- a/climpred/tests/conftest.py
+++ b/climpred/tests/conftest.py
@@ -8,29 +8,88 @@ from climpred.tutorial import load_dataset
 
 
 @pytest.fixture
-def PM_da_initialized_1d():
-    """MPI Perfect-model-framework initialized timeseries xr.DataArray."""
-    return load_dataset('MPI-PM-DP-1D')['tos'].isel(area=1, period=-1)
+def PM_ds_initialized_1d():
+    """MPI Perfect-model-framework initialized timeseries xr.Dataset."""
+    return load_dataset('MPI-PM-DP-1D').isel(area=1, period=-1)
 
 
 @pytest.fixture
-def PM_da_initialized_3d():
+def PM_da_initialized_1d(PM_ds_initialized_1d):
+    """MPI Perfect-model-framework initialized timeseries xr.DataArray."""
+    return PM_ds_initialized_1d['tos']
+
+
+@pytest.fixture
+def PM_da_initialized_1d_lead0(PM_da_initialized_1d):
+    da = PM_da_initialized_1d
+    # Convert to lead zero for testing
+    da['lead'] -= 1
+    da['init'] += 1
+    return da
+
+
+@pytest.fixture
+def PM_ds_initialized_3d_full():
+    """MPI Perfect-model-framework initialized global maps xr.Dataset."""
+    return load_dataset('MPI-PM-DP-3D')
+
+
+@pytest.fixture
+def PM_da_initialized_3d_full(PM_ds_initialized_3d_full):
+    """MPI Perfect-model-framework initialized global maps xr.Dataset."""
+    return PM_ds_initialized_3d_full['tos']
+
+
+@pytest.fixture
+def PM_ds_initialized_3d(PM_ds_initialized_3d_full):
+    """MPI Perfect-model-framework initialized maps xr.Dataset of subselected North
+    Atlantic."""
+    return PM_ds_initialized_3d_full.sel(x=slice(120, 130), y=slice(50, 60))
+
+
+@pytest.fixture
+def PM_da_initialized_3d(PM_ds_initialized_3d):
     """MPI Perfect-model-framework initialized maps xr.DataArray of subselected North
     Atlantic."""
-    return load_dataset('MPI-PM-DP-3D')['tos'].sel(x=slice(120, 130), y=slice(50, 60))
+    return PM_ds_initialized_3d['tos']
 
 
 @pytest.fixture
-def PM_da_control_1d():
+def PM_ds_control_1d():
+    """To MPI Perfect-model-framework corresponding control timeseries xr.Dataset."""
+    return load_dataset('MPI-control-1D').isel(area=1, period=-1)
+
+
+@pytest.fixture
+def PM_da_control_1d(PM_ds_control_1d):
     """To MPI Perfect-model-framework corresponding control timeseries xr.DataArray."""
-    return load_dataset('MPI-control-1D')['tos'].isel(area=1, period=-1)
+    return PM_ds_control_1d['tos']
 
 
 @pytest.fixture
-def PM_da_control_3d():
+def PM_ds_control_3d_full():
+    """To MPI Perfect-model-framework corresponding control global maps xr.Dataset."""
+    return load_dataset('MPI-control-3D')
+
+
+@pytest.fixture
+def PM_da_control_3d_full(PM_ds_control_3d_full):
+    """To MPI Perfect-model-framework corresponding control global maps xr.DataArray."""
+    return PM_ds_control_3d_full['tos']
+
+
+@pytest.fixture
+def PM_ds_control_3d(PM_ds_control_3d_full):
+    """To MPI Perfect-model-framework corresponding control maps xr.Dataset of
+    subselected North Atlantic."""
+    return PM_ds_control_3d_full.sel(x=slice(120, 130), y=slice(50, 60))
+
+
+@pytest.fixture
+def PM_da_control_3d(PM_ds_control_3d):
     """To MPI Perfect-model-framework corresponding control maps xr.DataArray of
     subselected North Atlantic."""
-    return load_dataset('MPI-control-3D')['tos'].sel(x=slice(120, 130), y=slice(50, 60))
+    return PM_ds_control_3d['tos']
 
 
 @pytest.fixture
@@ -58,12 +117,22 @@ def hind_da_initialized_1d(hind_ds_initialized_1d):
 
 
 @pytest.fixture
-def hind_da_initialized_3d():
-    """CESM-DPLE initialized hindcast maps mean removed xr.DataArray."""
-    da = load_dataset('CESM-DP-SST-3D')['SST'].isel(
-        nlon=slice(0, 10), nlat=slice(0, 12)
-    )
+def hind_ds_initialized_3d_full():
+    """CESM-DPLE initialized hindcast Pacific maps mean removed xr.Dataset."""
+    da = load_dataset('CESM-DP-SST-3D')
     return da - da.mean('init')
+
+
+@pytest.fixture
+def hind_ds_initialized_3d(hind_ds_initialized_3d_full):
+    """CESM-DPLE initialized hindcast Pacific maps mean removed xr.Dataset."""
+    return hind_ds_initialized_3d_full.isel(nlon=slice(0, 10), nlat=slice(0, 12))
+
+
+@pytest.fixture
+def hind_da_initialized_3d(hind_ds_initialized_3d):
+    """CESM-DPLE initialized hindcast Pacific maps mean removed xr.DataArray."""
+    return hind_ds_initialized_3d['SST']
 
 
 @pytest.fixture
@@ -97,12 +166,25 @@ def reconstruction_da_1d(reconstruction_ds_1d):
 
 
 @pytest.fixture
-def reconstruction_da_3d():
+def reconstruction_ds_3d_full():
+    """CESM-FOSI historical Pacific reconstruction maps members mean removed
+    xr.Dataset."""
+    ds = load_dataset('FOSI-SST-3D')
+    return ds - ds.mean('time')
+
+
+@pytest.fixture
+def reconstruction_ds_3d(reconstruction_ds_3d_full):
+    """CESM-FOSI historical reconstruction maps members mean removed
+    xr.Dataset."""
+    return reconstruction_ds_3d_full.isel(nlon=slice(0, 10), nlat=slice(0, 12))
+
+
+@pytest.fixture
+def reconstruction_da_3d(reconstruction_ds_3d):
     """CESM-FOSI historical reconstruction maps members mean removed
     xr.DataArray."""
-    da = load_dataset('FOSI-SST-3D')['SST'].isel(nlon=slice(0, 10), nlat=slice(0, 12))
-    da = da - da.mean('time')
-    return da
+    return reconstruction_ds_3d['SST']
 
 
 @pytest.fixture
@@ -162,3 +244,28 @@ def da_lead():
         dims=['init', 'lead'],
         coords=[init, lead],
     )
+
+
+@pytest.fixture
+def two_dim_da():
+    """xr.DataArray with two dims."""
+    da = xr.DataArray(
+        np.vstack(
+            [
+                np.arange(0, 5, 1.0),
+                np.arange(0, 10, 2.0),
+                np.arange(0, 40, 8.0),
+                np.arange(0, 20, 4.0),
+            ]
+        ),
+        dims=['row', 'col'],
+    )
+    return da
+
+
+@pytest.fixture
+def multi_dim_ds():
+    """xr.Dataset with multi-dimensional coords."""
+    ds = xr.tutorial.open_dataset('air_temperature')
+    ds = ds.assign(**{'airx2': ds['air'] * 2})
+    return ds

--- a/climpred/tests/conftest.py
+++ b/climpred/tests/conftest.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from climpred import PerfectModelEnsemble
 from climpred.tutorial import load_dataset
 
 # ordering: PM MPI, CESM; xr.Dataset, xr.DataArray; 1D, 3D
@@ -92,6 +93,14 @@ def PM_da_control_3d(PM_ds_control_3d):
     """To MPI Perfect-model-framework corresponding control maps xr.DataArray of
     subselected North Atlantic."""
     return PM_ds_control_3d['tos']
+
+
+@pytest.fixture
+def perfectModelEnsemble_initialized_control(PM_ds_initialized_1d, PM_ds_control_1d):
+    """PerfectModelEnsemble initialized with `initialized` and `control` xr.Dataset."""
+    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
+    pm = pm.add_control(PM_ds_control_1d)
+    return pm
 
 
 @pytest.fixture

--- a/climpred/tests/conftest.py
+++ b/climpred/tests/conftest.py
@@ -4,17 +4,33 @@ import xarray as xr
 
 from climpred.tutorial import load_dataset
 
+# ordering: PM MPI, CESM; xr.Dataset, xr.DataArray; 1D, 3D
+
 
 @pytest.fixture
-def PM_da_ds_1d():
+def PM_da_initialized_1d():
     """MPI Perfect-model-framework initialized timeseries xr.DataArray."""
     return load_dataset('MPI-PM-DP-1D')['tos'].isel(area=1, period=-1)
+
+
+@pytest.fixture
+def PM_da_initialized_3d():
+    """MPI Perfect-model-framework initialized maps xr.DataArray of subselected North
+    Atlantic."""
+    return load_dataset('MPI-PM-DP-3D')['tos'].sel(x=slice(120, 130), y=slice(50, 60))
 
 
 @pytest.fixture
 def PM_da_control_1d():
     """To MPI Perfect-model-framework corresponding control timeseries xr.DataArray."""
     return load_dataset('MPI-control-1D')['tos'].isel(area=1, period=-1)
+
+
+@pytest.fixture
+def PM_da_control_3d():
+    """To MPI Perfect-model-framework corresponding control maps xr.DataArray of
+    subselected North Atlantic."""
+    return load_dataset('MPI-control-3D')['tos'].sel(x=slice(120, 130), y=slice(50, 60))
 
 
 @pytest.fixture
@@ -47,8 +63,7 @@ def hind_da_initialized_3d():
     da = load_dataset('CESM-DP-SST-3D')['SST'].isel(
         nlon=slice(0, 10), nlat=slice(0, 12)
     )
-    da = da - da.mean('init')
-    return da
+    return da - da.mean('init')
 
 
 @pytest.fixture

--- a/climpred/tests/conftest.py
+++ b/climpred/tests/conftest.py
@@ -21,6 +21,8 @@ def PM_da_initialized_1d(PM_ds_initialized_1d):
 
 @pytest.fixture
 def PM_da_initialized_1d_lead0(PM_da_initialized_1d):
+    """MPI Perfect-model-framework initialized timeseries xr.DataArray in lead-0
+    framework."""
     da = PM_da_initialized_1d
     # Convert to lead zero for testing
     da['lead'] -= 1

--- a/climpred/tests/test_checks.py
+++ b/climpred/tests/test_checks.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import xarray as xr
 
 from climpred.checks import (
     has_dataset,
@@ -34,7 +33,7 @@ def _arbitrary_two_xr_func_random_loc(ds_da1, some_arg, ds_da2, **kwargs):
     return ds_da1, some_arg, ds_da2, kwargs
 
 
-@is_xarray([0, "da", "other_da"])
+@is_xarray([0, 'da', 'other_da'])
 def _arbitrary_three_xr_func_args_keys(ds, da=None, other_da=None, **kwargs):
     """Function for testing if checking the first in arg list and the
     keywords da/other_da is ds/da."""
@@ -43,59 +42,59 @@ def _arbitrary_three_xr_func_args_keys(ds, da=None, other_da=None, **kwargs):
 
 def test_is_xarray_ds(ds1):
     """Test if checking the first item in arg list is ds."""
-    ds, args, kwargs = _arbitrary_ds_da_func(ds1, "arg1", "arg2", kwarg1="kwarg1")
+    ds, args, kwargs = _arbitrary_ds_da_func(ds1, 'arg1', 'arg2', kwarg1='kwarg1')
     assert (ds1 == ds).all()
-    assert args == ("arg1", "arg2")
-    assert kwargs == {"kwarg1": "kwarg1"}
+    assert args == ('arg1', 'arg2')
+    assert kwargs == {'kwarg1': 'kwarg1'}
 
 
 def test_is_xarray_not_ds():
     """Test if checking the first item in arg list is not a ds/da, raise an error."""
-    not_a_ds = "not_a_ds"
+    not_a_ds = 'not_a_ds'
     with pytest.raises(IOError) as e:
-        _arbitrary_ds_da_func(not_a_ds, "arg1", "arg2", kwarg1="kwarg1")
-    assert "The input data is not an xarray" in str(e.value)
+        _arbitrary_ds_da_func(not_a_ds, 'arg1', 'arg2', kwarg1='kwarg1')
+    assert 'The input data is not an xarray' in str(e.value)
 
 
 def test_is_xarray_da(da1):
     """Test if checking the first item in arg list is da."""
-    da, args, kwargs = _arbitrary_ds_da_func(da1, "arg1", "arg2", kwarg1="kwarg1")
+    da, args, kwargs = _arbitrary_ds_da_func(da1, 'arg1', 'arg2', kwarg1='kwarg1')
     assert (da1 == da).all()
-    assert args == ("arg1", "arg2")
-    assert kwargs == {"kwarg1": "kwarg1"}
+    assert args == ('arg1', 'arg2')
+    assert kwargs == {'kwarg1': 'kwarg1'}
 
 
 def test_is_xarray_ds_da(ds1, da1):
     """Test if checking the first two items in arg list is ds/da."""
     ds, da, args, kwargs = _arbitrary_two_xr_func(
-        ds1, da1, "arg1", kwarg1="kwarg1", kwarg2="kwarg2"
+        ds1, da1, 'arg1', kwarg1='kwarg1', kwarg2='kwarg2'
     )
     assert (ds1 == ds).all()
     assert (da1 == da).all()
-    assert args == ("arg1",)
-    assert kwargs == {"kwarg1": "kwarg1", "kwarg2": "kwarg2"}
+    assert args == ('arg1',)
+    assert kwargs == {'kwarg1': 'kwarg1', 'kwarg2': 'kwarg2'}
 
 
 def test_is_xarray_ds_da_random_loc(ds1, da1):
     """Test if checking the first and third items in arg list is ds/da."""
     ds, arg, da, kwargs = _arbitrary_two_xr_func_random_loc(
-        ds1, "arg1", da1, kwarg1="kwarg1", kwarg2="kwarg2"
+        ds1, 'arg1', da1, kwarg1='kwarg1', kwarg2='kwarg2'
     )
     assert (ds1 == ds).all()
     assert (da1 == da).all()
-    assert arg == "arg1"
-    assert kwargs == {"kwarg1": "kwarg1", "kwarg2": "kwarg2"}
+    assert arg == 'arg1'
+    assert kwargs == {'kwarg1': 'kwarg1', 'kwarg2': 'kwarg2'}
 
 
 def test_is_xarray_ds_da_args_keys(ds1, da1, da2):
     """Test if checking the args and kwargs are ds/da."""
     ds, da, other_da, kwargs = _arbitrary_three_xr_func_args_keys(
-        ds1, da=da1, other_da=da2, kwarg1="kwarg1"
+        ds1, da=da1, other_da=da2, kwarg1='kwarg1'
     )
     assert (ds1 == ds).all()
     assert (da1 == da).all()
     assert (da2 == other_da).all()
-    assert kwargs == {"kwarg1": "kwarg1"}
+    assert kwargs == {'kwarg1': 'kwarg1'}
 
 
 def test_is_xarray_ds_da_args_keys_not(ds1, da2):
@@ -103,9 +102,9 @@ def test_is_xarray_ds_da_args_keys_not(ds1, da2):
     not_a_da = np.array([0, 1, 2])
     with pytest.raises(IOError) as e:
         _arbitrary_three_xr_func_args_keys(
-            ds1, da=not_a_da, other_da=da2, kwarg1="kwarg1"
+            ds1, da=not_a_da, other_da=da2, kwarg1='kwarg1'
         )
-    assert "The input data is not an xarray" in str(e.value)
+    assert 'The input data is not an xarray' in str(e.value)
 
 
 class _ArbitraryClass:
@@ -117,71 +116,71 @@ class _ArbitraryClass:
 def test_is_xarray_class_not():
     """Function for testing if checking class init is ds/da, it raises an error."""
     with pytest.raises(IOError) as e:
-        _ArbitraryClass("totally not a ds")
-    assert "The input data is not an xarray" in str(e.value)
+        _ArbitraryClass('totally not a ds')
+    assert 'The input data is not an xarray' in str(e.value)
 
 
 def test_has_dims_str(da1):
     """Test if check works for a string."""
-    assert has_dims(da1, "x", "arbitrary")
+    assert has_dims(da1, 'x', 'arbitrary')
 
 
 def test_has_dims_list(da1):
     """Test if check works for a list."""
     # returns None if no errors
-    assert has_dims(da1, ["x", "y"], "arbitrary")
+    assert has_dims(da1, ['x', 'y'], 'arbitrary')
 
 
 def test_has_dims_str_fail(da1):
     """Test if check fails properly for a string."""
     with pytest.raises(DimensionError) as e:
-        has_dims(da1, "z", "arbitrary")
-    assert "Your arbitrary object must contain" in str(e.value)
+        has_dims(da1, 'z', 'arbitrary')
+    assert 'Your arbitrary object must contain' in str(e.value)
 
 
 def test_has_dims_list_fail(da1):
     """Test if check fails properly for a list."""
     with pytest.raises(DimensionError) as e:
-        has_dims(da1, ["z"], "arbitrary")
-    assert "Your arbitrary object must contain" in str(e.value)
+        has_dims(da1, ['z'], 'arbitrary')
+    assert 'Your arbitrary object must contain' in str(e.value)
 
 
 def test_has_min_len_arr(da1):
     """Test if check works for min len."""
-    assert has_min_len(da1.values, 2, "arbitrary")
+    assert has_min_len(da1.values, 2, 'arbitrary')
 
 
 def test_has_min_len_fail(da1):
     """Test if check fails properly."""
     with pytest.raises(DimensionError) as e:
-        has_min_len(da1.values, 5, "arbitrary")
-    assert "Your arbitrary array must be at least" in str(e.value)
+        has_min_len(da1.values, 5, 'arbitrary')
+    assert 'Your arbitrary array must be at least' in str(e.value)
 
 
 def test_has_dataset():
     """Test if check works for a non-empty list."""
     obj = [5]
-    assert has_dataset(obj, "list", "something")
+    assert has_dataset(obj, 'list', 'something')
 
 
 def test_has_dataset_fail():
     """Test if check works to fail for an empty list."""
     obj = []
     with pytest.raises(DatasetError) as e:
-        has_dataset(obj, "test", "something")
-    assert "You need to add at least one test dataset" in str(e.value)
+        has_dataset(obj, 'test', 'something')
+    assert 'You need to add at least one test dataset' in str(e.value)
 
 
 def test_match_initialized_dims(da1, da2):
     """Test if check works if both da has the proper dims."""
-    assert match_initialized_dims(da1.rename({"y": "init"}), da2.rename({"y": "time"}))
+    assert match_initialized_dims(da1.rename({'y': 'init'}), da2.rename({'y': 'time'}))
 
 
 def test_match_initialized_dims_fail(da1, da2):
     """Test if check works if the da does not have the proper dims."""
     with pytest.raises(DimensionError) as e:
-        match_initialized_dims(da1.rename({"y": "init"}), da2.rename({"y": "not_time"}))
-    assert "Dimensions must match initialized prediction" in str(e.value)
+        match_initialized_dims(da1.rename({'y': 'init'}), da2.rename({'y': 'not_time'}))
+    assert 'Dimensions must match initialized prediction' in str(e.value)
 
 
 def test_match_initialized_vars(ds1, ds2):
@@ -192,28 +191,28 @@ def test_match_initialized_vars(ds1, ds2):
 def test_match_initialized_vars_fail(ds1, ds2):
     """Test if check works if both do not have the same variables."""
     with pytest.raises(VariableError) as e:
-        match_initialized_vars(ds1, ds2.rename({"air": "tmp"}))
-    assert "Please provide a Dataset/DataArray with at least" in str(e.value)
+        match_initialized_vars(ds1, ds2.rename({'air': 'tmp'}))
+    assert 'Please provide a Dataset/DataArray with at least' in str(e.value)
 
 
 def test_is_in_list():
     """Test if check works if key is in dict."""
-    some_list = ["key"]
-    assert is_in_list("key", some_list, "metric")
+    some_list = ['key']
+    assert is_in_list('key', some_list, 'metric')
 
 
 def test_is_in_list_fail():
     """Test if check works if key is not in dict."""
-    some_list = ["key"]
+    some_list = ['key']
     with pytest.raises(KeyError) as e:
-        is_in_list("not_key", some_list, "metric")
-    assert "Specify metric from" in str(e.value)
+        is_in_list('not_key', some_list, 'metric')
+    assert 'Specify metric from' in str(e.value)
 
 
-@pytest.mark.parametrize("lead_units", VALID_LEAD_UNITS)
+@pytest.mark.parametrize('lead_units', VALID_LEAD_UNITS)
 def test_valid_lead_units(da_lead, lead_units):
     """Test that lead units check passes with appropriate lead units."""
-    da_lead["lead"].attrs["units"] = lead_units
+    da_lead['lead'].attrs['units'] = lead_units
     assert has_valid_lead_units(da_lead)
 
 
@@ -225,15 +224,15 @@ def test_valid_lead_units_no_units(da_lead):
 
 def test_valid_lead_units_invalid_units(da_lead):
     """Test that valid lead units check breaks if invalid units provided."""
-    da_lead["lead"].attrs["units"] = "dummy"
+    da_lead['lead'].attrs['units'] = 'dummy'
     with pytest.raises(AttributeError):
         has_valid_lead_units(da_lead)
 
 
-@pytest.mark.parametrize("lead_units", VALID_LEAD_UNITS)
+@pytest.mark.parametrize('lead_units', VALID_LEAD_UNITS)
 def test_nonplural_lead_units_works(da_lead, lead_units):
     """Test that non-plural lead units work on lead units check."""
-    da_lead["lead"].attrs["units"] = lead_units[:-1]
+    da_lead['lead'].attrs['units'] = lead_units[:-1]
     with pytest.warns(UserWarning) as record:
         has_valid_lead_units(da_lead)
     expected = f'The letter "s" was appended to the lead units; now {lead_units}.'

--- a/climpred/tests/test_checks.py
+++ b/climpred/tests/test_checks.py
@@ -16,41 +16,6 @@ from climpred.constants import VALID_LEAD_UNITS
 from climpred.exceptions import DatasetError, DimensionError, VariableError
 
 
-@pytest.fixture
-def ds1():
-    return xr.Dataset(
-        {'air': (('lon', 'lat'), [[0, 1, 2], [3, 4, 5], [6, 7, 8]])},
-        coords={'lon': [1, 3, 4], 'lat': [5, 6, 7]},
-    )
-
-
-@pytest.fixture
-def ds2():
-    return xr.Dataset(
-        {'air': (('lon', 'lat'), [[0, 1, 2], [3, 4, 5], [6, 7, 8]])},
-        coords={'lon': [1, 3, 6], 'lat': [5, 6, 9]},
-    )
-
-
-@pytest.fixture
-def da1():
-    return xr.DataArray([[0, 1], [3, 4], [6, 7]], dims=('x', 'y'))
-
-
-@pytest.fixture
-def da2():
-    return xr.DataArray([[0, 1], [5, 6], [6, 7]], dims=('x', 'y'))
-
-
-@pytest.fixture
-def da_lead_time():
-    lead = np.arange(5)
-    init = np.arange(5)
-    return xr.DataArray(
-        np.random.rand(len(lead), len(init)), dims=['init', 'lead'], coords=[init, lead]
-    )
-
-
 @is_xarray(0)
 def _arbitrary_ds_da_func(ds_da, *args, **kwargs):
     """Function for testing if checking the first item in arg list is ds/da."""
@@ -69,7 +34,7 @@ def _arbitrary_two_xr_func_random_loc(ds_da1, some_arg, ds_da2, **kwargs):
     return ds_da1, some_arg, ds_da2, kwargs
 
 
-@is_xarray([0, 'da', 'other_da'])
+@is_xarray([0, "da", "other_da"])
 def _arbitrary_three_xr_func_args_keys(ds, da=None, other_da=None, **kwargs):
     """Function for testing if checking the first in arg list and the
     keywords da/other_da is ds/da."""
@@ -78,59 +43,63 @@ def _arbitrary_three_xr_func_args_keys(ds, da=None, other_da=None, **kwargs):
 
 def test_is_xarray_ds(ds1):
     """Test if checking the first item in arg list is ds."""
-    ds, args, kwargs = _arbitrary_ds_da_func(ds1, 'arg1', 'arg2', kwarg1='kwarg1')
+    ds, args, kwargs = _arbitrary_ds_da_func(
+        ds1, "arg1", "arg2", kwarg1="kwarg1"
+    )
     assert (ds1 == ds).all()
-    assert args == ('arg1', 'arg2')
-    assert kwargs == {'kwarg1': 'kwarg1'}
+    assert args == ("arg1", "arg2")
+    assert kwargs == {"kwarg1": "kwarg1"}
 
 
 def test_is_xarray_not_ds():
     """Test if checking the first item in arg list is not a ds/da, raise an error."""
-    not_a_ds = 'not_a_ds'
+    not_a_ds = "not_a_ds"
     with pytest.raises(IOError) as e:
-        _arbitrary_ds_da_func(not_a_ds, 'arg1', 'arg2', kwarg1='kwarg1')
-    assert 'The input data is not an xarray' in str(e.value)
+        _arbitrary_ds_da_func(not_a_ds, "arg1", "arg2", kwarg1="kwarg1")
+    assert "The input data is not an xarray" in str(e.value)
 
 
 def test_is_xarray_da(da1):
     """Test if checking the first item in arg list is da."""
-    da, args, kwargs = _arbitrary_ds_da_func(da1, 'arg1', 'arg2', kwarg1='kwarg1')
+    da, args, kwargs = _arbitrary_ds_da_func(
+        da1, "arg1", "arg2", kwarg1="kwarg1"
+    )
     assert (da1 == da).all()
-    assert args == ('arg1', 'arg2')
-    assert kwargs == {'kwarg1': 'kwarg1'}
+    assert args == ("arg1", "arg2")
+    assert kwargs == {"kwarg1": "kwarg1"}
 
 
 def test_is_xarray_ds_da(ds1, da1):
     """Test if checking the first two items in arg list is ds/da."""
     ds, da, args, kwargs = _arbitrary_two_xr_func(
-        ds1, da1, 'arg1', kwarg1='kwarg1', kwarg2='kwarg2'
+        ds1, da1, "arg1", kwarg1="kwarg1", kwarg2="kwarg2"
     )
     assert (ds1 == ds).all()
     assert (da1 == da).all()
-    assert args == ('arg1',)
-    assert kwargs == {'kwarg1': 'kwarg1', 'kwarg2': 'kwarg2'}
+    assert args == ("arg1",)
+    assert kwargs == {"kwarg1": "kwarg1", "kwarg2": "kwarg2"}
 
 
 def test_is_xarray_ds_da_random_loc(ds1, da1):
     """Test if checking the first and third items in arg list is ds/da."""
     ds, arg, da, kwargs = _arbitrary_two_xr_func_random_loc(
-        ds1, 'arg1', da1, kwarg1='kwarg1', kwarg2='kwarg2'
+        ds1, "arg1", da1, kwarg1="kwarg1", kwarg2="kwarg2"
     )
     assert (ds1 == ds).all()
     assert (da1 == da).all()
-    assert arg == 'arg1'
-    assert kwargs == {'kwarg1': 'kwarg1', 'kwarg2': 'kwarg2'}
+    assert arg == "arg1"
+    assert kwargs == {"kwarg1": "kwarg1", "kwarg2": "kwarg2"}
 
 
 def test_is_xarray_ds_da_args_keys(ds1, da1, da2):
     """Test if checking the args and kwargs are ds/da."""
     ds, da, other_da, kwargs = _arbitrary_three_xr_func_args_keys(
-        ds1, da=da1, other_da=da2, kwarg1='kwarg1'
+        ds1, da=da1, other_da=da2, kwarg1="kwarg1"
     )
     assert (ds1 == ds).all()
     assert (da1 == da).all()
     assert (da2 == other_da).all()
-    assert kwargs == {'kwarg1': 'kwarg1'}
+    assert kwargs == {"kwarg1": "kwarg1"}
 
 
 def test_is_xarray_ds_da_args_keys_not(ds1, da2):
@@ -138,9 +107,9 @@ def test_is_xarray_ds_da_args_keys_not(ds1, da2):
     not_a_da = np.array([0, 1, 2])
     with pytest.raises(IOError) as e:
         _arbitrary_three_xr_func_args_keys(
-            ds1, da=not_a_da, other_da=da2, kwarg1='kwarg1'
+            ds1, da=not_a_da, other_da=da2, kwarg1="kwarg1"
         )
-    assert 'The input data is not an xarray' in str(e.value)
+    assert "The input data is not an xarray" in str(e.value)
 
 
 class _ArbitraryClass:
@@ -152,71 +121,75 @@ class _ArbitraryClass:
 def test_is_xarray_class_not():
     """Function for testing if checking class init is ds/da, it raises an error."""
     with pytest.raises(IOError) as e:
-        _ArbitraryClass('totally not a ds')
-    assert 'The input data is not an xarray' in str(e.value)
+        _ArbitraryClass("totally not a ds")
+    assert "The input data is not an xarray" in str(e.value)
 
 
 def test_has_dims_str(da1):
     """Test if check works for a string."""
-    assert has_dims(da1, 'x', 'arbitrary')
+    assert has_dims(da1, "x", "arbitrary")
 
 
 def test_has_dims_list(da1):
     """Test if check works for a list."""
     # returns None if no errors
-    assert has_dims(da1, ['x', 'y'], 'arbitrary')
+    assert has_dims(da1, ["x", "y"], "arbitrary")
 
 
 def test_has_dims_str_fail(da1):
     """Test if check fails properly for a string."""
     with pytest.raises(DimensionError) as e:
-        has_dims(da1, 'z', 'arbitrary')
-    assert 'Your arbitrary object must contain' in str(e.value)
+        has_dims(da1, "z", "arbitrary")
+    assert "Your arbitrary object must contain" in str(e.value)
 
 
 def test_has_dims_list_fail(da1):
     """Test if check fails properly for a list."""
     with pytest.raises(DimensionError) as e:
-        has_dims(da1, ['z'], 'arbitrary')
-    assert 'Your arbitrary object must contain' in str(e.value)
+        has_dims(da1, ["z"], "arbitrary")
+    assert "Your arbitrary object must contain" in str(e.value)
 
 
 def test_has_min_len_arr(da1):
     """Test if check works for min len."""
-    assert has_min_len(da1.values, 2, 'arbitrary')
+    assert has_min_len(da1.values, 2, "arbitrary")
 
 
 def test_has_min_len_fail(da1):
     """Test if check fails properly."""
     with pytest.raises(DimensionError) as e:
-        has_min_len(da1.values, 5, 'arbitrary')
-    assert 'Your arbitrary array must be at least' in str(e.value)
+        has_min_len(da1.values, 5, "arbitrary")
+    assert "Your arbitrary array must be at least" in str(e.value)
 
 
 def test_has_dataset():
     """Test if check works for a non-empty list."""
     obj = [5]
-    assert has_dataset(obj, 'list', 'something')
+    assert has_dataset(obj, "list", "something")
 
 
 def test_has_dataset_fail():
     """Test if check works to fail for an empty list."""
     obj = []
     with pytest.raises(DatasetError) as e:
-        has_dataset(obj, 'test', 'something')
-    assert 'You need to add at least one test dataset' in str(e.value)
+        has_dataset(obj, "test", "something")
+    assert "You need to add at least one test dataset" in str(e.value)
 
 
 def test_match_initialized_dims(da1, da2):
     """Test if check works if both da has the proper dims."""
-    assert match_initialized_dims(da1.rename({'y': 'init'}), da2.rename({'y': 'time'}))
+    assert match_initialized_dims(
+        da1.rename({"y": "init"}), da2.rename({"y": "time"})
+    )
 
 
 def test_match_initialized_dims_fail(da1, da2):
     """Test if check works if the da does not have the proper dims."""
     with pytest.raises(DimensionError) as e:
-        match_initialized_dims(da1.rename({'y': 'init'}), da2.rename({'y': 'not_time'}))
-    assert 'Dimensions must match initialized prediction' in str(e.value)
+        match_initialized_dims(
+            da1.rename({"y": "init"}), da2.rename({"y": "not_time"})
+        )
+    assert "Dimensions must match initialized prediction" in str(e.value)
 
 
 def test_match_initialized_vars(ds1, ds2):
@@ -227,49 +200,51 @@ def test_match_initialized_vars(ds1, ds2):
 def test_match_initialized_vars_fail(ds1, ds2):
     """Test if check works if both do not have the same variables."""
     with pytest.raises(VariableError) as e:
-        match_initialized_vars(ds1, ds2.rename({'air': 'tmp'}))
-    assert 'Please provide a Dataset/DataArray with at least' in str(e.value)
+        match_initialized_vars(ds1, ds2.rename({"air": "tmp"}))
+    assert "Please provide a Dataset/DataArray with at least" in str(e.value)
 
 
 def test_is_in_list():
     """Test if check works if key is in dict."""
-    some_list = ['key']
-    assert is_in_list('key', some_list, 'metric')
+    some_list = ["key"]
+    assert is_in_list("key", some_list, "metric")
 
 
 def test_is_in_list_fail():
     """Test if check works if key is not in dict."""
-    some_list = ['key']
+    some_list = ["key"]
     with pytest.raises(KeyError) as e:
-        is_in_list('not_key', some_list, 'metric')
-    assert 'Specify metric from' in str(e.value)
+        is_in_list("not_key", some_list, "metric")
+    assert "Specify metric from" in str(e.value)
 
 
-@pytest.mark.parametrize('lead_units', VALID_LEAD_UNITS)
-def test_valid_lead_units(da_lead_time, lead_units):
+@pytest.mark.parametrize("lead_units", VALID_LEAD_UNITS)
+def test_valid_lead_units(da_lead, lead_units):
     """Test that lead units check passes with appropriate lead units."""
-    da_lead_time['lead'].attrs['units'] = lead_units
-    assert has_valid_lead_units(da_lead_time)
+    da_lead["lead"].attrs["units"] = lead_units
+    assert has_valid_lead_units(da_lead)
 
 
-def test_valid_lead_units_no_units(da_lead_time):
+def test_valid_lead_units_no_units(da_lead):
     """Test that valid lead units check breaks if there are no units."""
     with pytest.raises(AttributeError):
-        has_valid_lead_units(da_lead_time)
+        has_valid_lead_units(da_lead)
 
 
-def test_valid_lead_units_invalid_units(da_lead_time):
+def test_valid_lead_units_invalid_units(da_lead):
     """Test that valid lead units check breaks if invalid units provided."""
-    da_lead_time['lead'].attrs['units'] = 'dummy'
+    da_lead["lead"].attrs["units"] = "dummy"
     with pytest.raises(AttributeError):
-        has_valid_lead_units(da_lead_time)
+        has_valid_lead_units(da_lead)
 
 
-@pytest.mark.parametrize('lead_units', VALID_LEAD_UNITS)
-def test_nonplural_lead_units_works(da_lead_time, lead_units):
+@pytest.mark.parametrize("lead_units", VALID_LEAD_UNITS)
+def test_nonplural_lead_units_works(da_lead, lead_units):
     """Test that non-plural lead units work on lead units check."""
-    da_lead_time['lead'].attrs['units'] = lead_units[:-1]
+    da_lead["lead"].attrs["units"] = lead_units[:-1]
     with pytest.warns(UserWarning) as record:
-        has_valid_lead_units(da_lead_time)
-    expected = f'The letter "s" was appended to the lead units; now {lead_units}.'
+        has_valid_lead_units(da_lead)
+    expected = (
+        f'The letter "s" was appended to the lead units; now {lead_units}.'
+    )
     assert record[0].message.args[0] == expected

--- a/climpred/tests/test_checks.py
+++ b/climpred/tests/test_checks.py
@@ -43,9 +43,7 @@ def _arbitrary_three_xr_func_args_keys(ds, da=None, other_da=None, **kwargs):
 
 def test_is_xarray_ds(ds1):
     """Test if checking the first item in arg list is ds."""
-    ds, args, kwargs = _arbitrary_ds_da_func(
-        ds1, "arg1", "arg2", kwarg1="kwarg1"
-    )
+    ds, args, kwargs = _arbitrary_ds_da_func(ds1, "arg1", "arg2", kwarg1="kwarg1")
     assert (ds1 == ds).all()
     assert args == ("arg1", "arg2")
     assert kwargs == {"kwarg1": "kwarg1"}
@@ -61,9 +59,7 @@ def test_is_xarray_not_ds():
 
 def test_is_xarray_da(da1):
     """Test if checking the first item in arg list is da."""
-    da, args, kwargs = _arbitrary_ds_da_func(
-        da1, "arg1", "arg2", kwarg1="kwarg1"
-    )
+    da, args, kwargs = _arbitrary_ds_da_func(da1, "arg1", "arg2", kwarg1="kwarg1")
     assert (da1 == da).all()
     assert args == ("arg1", "arg2")
     assert kwargs == {"kwarg1": "kwarg1"}
@@ -178,17 +174,13 @@ def test_has_dataset_fail():
 
 def test_match_initialized_dims(da1, da2):
     """Test if check works if both da has the proper dims."""
-    assert match_initialized_dims(
-        da1.rename({"y": "init"}), da2.rename({"y": "time"})
-    )
+    assert match_initialized_dims(da1.rename({"y": "init"}), da2.rename({"y": "time"}))
 
 
 def test_match_initialized_dims_fail(da1, da2):
     """Test if check works if the da does not have the proper dims."""
     with pytest.raises(DimensionError) as e:
-        match_initialized_dims(
-            da1.rename({"y": "init"}), da2.rename({"y": "not_time"})
-        )
+        match_initialized_dims(da1.rename({"y": "init"}), da2.rename({"y": "not_time"}))
     assert "Dimensions must match initialized prediction" in str(e.value)
 
 
@@ -244,7 +236,5 @@ def test_nonplural_lead_units_works(da_lead, lead_units):
     da_lead["lead"].attrs["units"] = lead_units[:-1]
     with pytest.warns(UserWarning) as record:
         has_valid_lead_units(da_lead)
-    expected = (
-        f'The letter "s" was appended to the lead units; now {lead_units}.'
-    )
+    expected = f'The letter "s" was appended to the lead units; now {lead_units}.'
     assert record[0].message.args[0] == expected

--- a/climpred/tests/test_comparisons.py
+++ b/climpred/tests/test_comparisons.py
@@ -15,31 +15,16 @@ from climpred.comparisons import (
 from climpred.constants import PM_COMPARISONS, PM_METRICS, PROBABILISTIC_PM_COMPARISONS
 from climpred.metrics import __mse as metric
 from climpred.prediction import compute_perfect_model
-from climpred.tutorial import load_dataset
 from climpred.utils import get_comparison_class, get_metric_class
 
 
-@pytest.fixture
-def PM_da_ds1d():
-    da = load_dataset('MPI-PM-DP-1D')
-    da = da['tos']
-    return da
-
-
-@pytest.fixture
-def PM_da_control1d():
-    da = load_dataset('MPI-control-1D')
-    da = da['tos']
-    return da
-
-
-def test_e2c(PM_da_ds1d):
+def test_e2c(PM_da_ds_1d):
     """Test ensemble_mean-to-control (which can be any other one member) (e2c)
     comparison basic functionality.
 
     Clean comparison: Remove one control member from ensemble to use as reference.
     Take the remaining member mean as forecasts."""
-    ds = PM_da_ds1d
+    ds = PM_da_ds_1d
     aforecast, areference = __e2c.function(ds, metric=metric)
 
     control_member = [0]
@@ -59,13 +44,13 @@ def test_e2c(PM_da_ds1d):
     assert_equal(ereference, areference)
 
 
-def test_m2c(PM_da_ds1d):
+def test_m2c(PM_da_ds_1d):
     """Test many-to-control (which can be any other one member) (m2c) comparison basic
     functionality.
 
     Clean comparison: Remove one control member from ensemble to use as reference.
     Take the remaining members as forecasts."""
-    ds = PM_da_ds1d
+    ds = PM_da_ds_1d
     aforecast, areference = __m2c.function(ds, metric=metric)
 
     control_member = [0]
@@ -83,12 +68,12 @@ def test_m2c(PM_da_ds1d):
     assert_equal(ereference, areference)
 
 
-def test_m2e(PM_da_ds1d):
+def test_m2e(PM_da_ds_1d):
     """Test many-to-ensemble-mean (m2e) comparison basic functionality.
 
     Clean comparison: Remove one member from ensemble to use as reference.
     Take the remaining members as forecasts."""
-    ds = PM_da_ds1d
+    ds = PM_da_ds_1d
     aforecast, areference = __m2e.function(ds, metric=metric)
 
     reference_list = []
@@ -113,12 +98,12 @@ def test_m2e(PM_da_ds1d):
     assert_equal(ereference, areference)
 
 
-def test_m2m(PM_da_ds1d):
+def test_m2m(PM_da_ds_1d):
     """Test many-to-many (m2m) comparison basic functionality.
 
     Clean comparison: Remove one member from ensemble to use as reference. Take the
     remaining members as forecasts."""
-    ds = PM_da_ds1d
+    ds = PM_da_ds_1d
     aforecast, areference = __m2m.function(ds, metric=metric)
 
     reference_list = []
@@ -143,9 +128,9 @@ def test_m2m(PM_da_ds1d):
 
 @pytest.mark.parametrize('metric', ['crps', 'mse'])
 @pytest.mark.parametrize('comparison', PM_COMPARISONS)
-def test_all(PM_da_ds1d, comparison, metric):
+def test_all(PM_da_ds_1d, comparison, metric):
     metric = get_metric_class(metric, PM_METRICS)
-    ds = PM_da_ds1d
+    ds = PM_da_ds_1d
     comparison = get_comparison_class(comparison, PM_COMPARISONS)
     forecast, obs = comparison.function(ds, metric=metric)
     assert not forecast.isnull().any()
@@ -182,13 +167,13 @@ my_m2me_comparison = Comparison(
 
 
 @pytest.mark.parametrize('metric', ('rmse', 'pearson_r'))
-def test_new_comparison_passed_to_compute(PM_da_ds1d, PM_da_control1d, metric):
+def test_new_comparison_passed_to_compute(PM_da_ds_1d, PM_da_control_1d, metric):
     actual = compute_perfect_model(
-        PM_da_ds1d, PM_da_control1d, comparison=my_m2me_comparison, metric=metric,
+        PM_da_ds_1d, PM_da_control_1d, comparison=my_m2me_comparison, metric=metric,
     )
 
     expected = compute_perfect_model(
-        PM_da_ds1d, PM_da_control1d, comparison='m2e', metric='mse'
+        PM_da_ds_1d, PM_da_control_1d, comparison='m2e', metric='mse'
     )
 
     assert (actual - expected).mean() != 0

--- a/climpred/tests/test_comparisons.py
+++ b/climpred/tests/test_comparisons.py
@@ -18,13 +18,13 @@ from climpred.prediction import compute_perfect_model
 from climpred.utils import get_comparison_class, get_metric_class
 
 
-def test_e2c(PM_da_ds_1d):
+def test_e2c(PM_da_initialized_1d):
     """Test ensemble_mean-to-control (which can be any other one member) (e2c)
     comparison basic functionality.
 
     Clean comparison: Remove one control member from ensemble to use as reference.
     Take the remaining member mean as forecasts."""
-    ds = PM_da_ds_1d
+    ds = PM_da_initialized_1d
     aforecast, areference = __e2c.function(ds, metric=metric)
 
     control_member = [0]
@@ -44,13 +44,13 @@ def test_e2c(PM_da_ds_1d):
     assert_equal(ereference, areference)
 
 
-def test_m2c(PM_da_ds_1d):
+def test_m2c(PM_da_initialized_1d):
     """Test many-to-control (which can be any other one member) (m2c) comparison basic
     functionality.
 
     Clean comparison: Remove one control member from ensemble to use as reference.
     Take the remaining members as forecasts."""
-    ds = PM_da_ds_1d
+    ds = PM_da_initialized_1d
     aforecast, areference = __m2c.function(ds, metric=metric)
 
     control_member = [0]
@@ -68,12 +68,12 @@ def test_m2c(PM_da_ds_1d):
     assert_equal(ereference, areference)
 
 
-def test_m2e(PM_da_ds_1d):
+def test_m2e(PM_da_initialized_1d):
     """Test many-to-ensemble-mean (m2e) comparison basic functionality.
 
     Clean comparison: Remove one member from ensemble to use as reference.
     Take the remaining members as forecasts."""
-    ds = PM_da_ds_1d
+    ds = PM_da_initialized_1d
     aforecast, areference = __m2e.function(ds, metric=metric)
 
     reference_list = []
@@ -98,12 +98,12 @@ def test_m2e(PM_da_ds_1d):
     assert_equal(ereference, areference)
 
 
-def test_m2m(PM_da_ds_1d):
+def test_m2m(PM_da_initialized_1d):
     """Test many-to-many (m2m) comparison basic functionality.
 
     Clean comparison: Remove one member from ensemble to use as reference. Take the
     remaining members as forecasts."""
-    ds = PM_da_ds_1d
+    ds = PM_da_initialized_1d
     aforecast, areference = __m2m.function(ds, metric=metric)
 
     reference_list = []
@@ -128,9 +128,9 @@ def test_m2m(PM_da_ds_1d):
 
 @pytest.mark.parametrize('metric', ['crps', 'mse'])
 @pytest.mark.parametrize('comparison', PM_COMPARISONS)
-def test_all(PM_da_ds_1d, comparison, metric):
+def test_all(PM_da_initialized_1d, comparison, metric):
     metric = get_metric_class(metric, PM_METRICS)
-    ds = PM_da_ds_1d
+    ds = PM_da_initialized_1d
     comparison = get_comparison_class(comparison, PM_COMPARISONS)
     forecast, obs = comparison.function(ds, metric=metric)
     assert not forecast.isnull().any()
@@ -167,13 +167,18 @@ my_m2me_comparison = Comparison(
 
 
 @pytest.mark.parametrize('metric', ('rmse', 'pearson_r'))
-def test_new_comparison_passed_to_compute(PM_da_ds_1d, PM_da_control_1d, metric):
+def test_new_comparison_passed_to_compute(
+    PM_da_initialized_1d, PM_da_control_1d, metric
+):
     actual = compute_perfect_model(
-        PM_da_ds_1d, PM_da_control_1d, comparison=my_m2me_comparison, metric=metric,
+        PM_da_initialized_1d,
+        PM_da_control_1d,
+        comparison=my_m2me_comparison,
+        metric=metric,
     )
 
     expected = compute_perfect_model(
-        PM_da_ds_1d, PM_da_control_1d, comparison='m2e', metric='mse'
+        PM_da_initialized_1d, PM_da_control_1d, comparison='m2e', metric='mse'
     )
 
     assert (actual - expected).mean() != 0

--- a/climpred/tests/test_compute_dims.py
+++ b/climpred/tests/test_compute_dims.py
@@ -10,53 +10,17 @@ from climpred.constants import (
     PROBABILISTIC_PM_COMPARISONS,
 )
 from climpred.prediction import compute_hindcast, compute_perfect_model
-from climpred.tutorial import load_dataset
 from climpred.utils import get_comparison_class, get_metric_class
 
-
-@pytest.fixture
-def pm_da_ds1d():
-    da = load_dataset('MPI-PM-DP-1D')
-    da = da['tos'].isel(area=1, period=-1)
-    return da
-
-
-@pytest.fixture
-def pm_da_control1d():
-    da = load_dataset('MPI-control-1D')
-    da = da['tos'].isel(area=1, period=-1)
-    return da
-
-
-@pytest.fixture
-def initialized_da():
-    da = load_dataset('CESM-DP-SST')['SST']
-    da = da - da.mean('init')
-    return da
-
-
-@pytest.fixture
-def uninitialized_da():
-    da = load_dataset('CESM-LE')['SST']
-    # add member coordinate
-    da['member'] = range(1, 1 + da.member.size)
-    da = da - da.mean('time')
-    return da
-
-
-@pytest.fixture
-def observations_da():
-    da = load_dataset('ERSST')['SST']
-    da = da - da.mean('time')
-    return da
+bootstrap = 3
 
 
 @pytest.mark.parametrize('metric', ['crps', 'mse'])
 @pytest.mark.parametrize('comparison', PROBABILISTIC_PM_COMPARISONS)
-def test_pm_comparison_stack_dims_when_deterministic(pm_da_ds1d, comparison, metric):
+def test_pm_comparison_stack_dims_when_deterministic(PM_da_ds_1d, comparison, metric):
     metric = get_metric_class(metric, PM_METRICS)
     comparison = get_comparison_class(comparison, PM_COMPARISONS)
-    actual_f, actual_r = comparison.function(pm_da_ds1d, metric=metric)
+    actual_f, actual_r = comparison.function(PM_da_ds_1d, metric=metric)
     if not metric.probabilistic:
         assert 'member' in actual_f.dims
         assert 'member' in actual_r.dims
@@ -67,10 +31,16 @@ def test_pm_comparison_stack_dims_when_deterministic(pm_da_ds1d, comparison, met
 
 # cannot work for e2c, m2e comparison because only 1:1 comparison
 @pytest.mark.parametrize('comparison', PROBABILISTIC_PM_COMPARISONS)
-def test_compute_perfect_model_dim_over_member(pm_da_ds1d, pm_da_control1d, comparison):
+def test_compute_perfect_model_dim_over_member(
+    PM_da_ds_1d, PM_da_control_1d, comparison
+):
     """Test deterministic metric calc skill over member dim."""
     actual = compute_perfect_model(
-        pm_da_ds1d, pm_da_control1d, comparison=comparison, metric='rmse', dim='member'
+        PM_da_ds_1d,
+        PM_da_control_1d,
+        comparison=comparison,
+        metric='rmse',
+        dim='member',
     )
     assert 'init' in actual.dims
     assert not actual.isnull().any()
@@ -78,11 +48,13 @@ def test_compute_perfect_model_dim_over_member(pm_da_ds1d, pm_da_control1d, comp
 
 # cannot work for e2o comparison because only 1:1 comparison
 @pytest.mark.parametrize('comparison', PROBABILISTIC_HINDCAST_COMPARISONS)
-def test_compute_hindcast_dim_over_member(initialized_da, observations_da, comparison):
+def test_compute_hindcast_dim_over_member(
+    hind_da_initialized_1d, observations_da_1d, comparison
+):
     """Test deterministic metric calc skill over member dim."""
     actual = compute_hindcast(
-        initialized_da,
-        observations_da,
+        hind_da_initialized_1d,
+        observations_da_1d,
         comparison=comparison,
         metric='rmse',
         dim='member',
@@ -92,33 +64,35 @@ def test_compute_hindcast_dim_over_member(initialized_da, observations_da, compa
     assert not actual.mean('init').isnull().any()
 
 
-def test_compute_perfect_model_different_dims_quite_close(pm_da_ds1d, pm_da_control1d):
+def test_compute_perfect_model_different_dims_quite_close(
+    PM_da_ds_1d, PM_da_control_1d
+):
     """Test whether dim=['init','member'] and
     dim='member' results."""
     stack_dims_true = compute_perfect_model(
-        pm_da_ds1d,
-        pm_da_control1d,
+        PM_da_ds_1d,
+        PM_da_control_1d,
         comparison='m2c',
         metric='rmse',
         dim=['init', 'member'],
     )
     stack_dims_false = compute_perfect_model(
-        pm_da_ds1d, pm_da_control1d, comparison='m2c', metric='rmse', dim='member'
+        PM_da_ds_1d, PM_da_control_1d, comparison='m2c', metric='rmse', dim='member',
     ).mean(['init'])
     # no more than 10% difference
     assert_allclose(stack_dims_true, stack_dims_false, rtol=0.1, atol=0.03)
 
 
-def test_bootstrap_pm_dim(pm_da_ds1d, pm_da_control1d):
+def test_bootstrap_pm_dim(PM_da_ds_1d, PM_da_control_1d):
     """Test whether bootstrap_hindcast calcs skill over member dim and
     returns init dim."""
     actual = bootstrap_perfect_model(
-        pm_da_ds1d,
-        pm_da_control1d,
+        PM_da_ds_1d,
+        PM_da_control_1d,
         metric='rmse',
         dim='member',
         comparison='m2c',
-        bootstrap=3,
+        bootstrap=bootstrap,
     )
     assert 'init' in actual.dims
     for kind in ['init', 'uninit']:
@@ -129,17 +103,19 @@ def test_bootstrap_pm_dim(pm_da_ds1d, pm_da_control1d):
         assert not actualk
 
 
-def test_bootstrap_hindcast_dim(initialized_da, uninitialized_da, observations_da):
+def test_bootstrap_hindcast_dim(
+    hind_da_initialized_1d, hind_da_uninitialized_1d, observations_da_1d
+):
     """Test whether bootstrap_hindcast calcs skill over member dim and
     returns init dim."""
     actual = bootstrap_hindcast(
-        initialized_da,
-        uninitialized_da,
-        observations_da,
+        hind_da_initialized_1d,
+        hind_da_uninitialized_1d,
+        observations_da_1d,
         metric='rmse',
         dim='member',
         comparison='m2o',
-        bootstrap=3,
+        bootstrap=bootstrap,
     )
     assert 'init' in actual.dims
     for kind in ['init', 'uninit']:
@@ -153,11 +129,11 @@ def test_bootstrap_hindcast_dim(initialized_da, uninitialized_da, observations_d
 @pytest.mark.parametrize('metric', ('rmse', 'crpss'))
 @pytest.mark.parametrize('comparison', PROBABILISTIC_PM_COMPARISONS)
 @pytest.mark.parametrize('dim', ('init', 'member', ['init', 'member']))
-def test_compute_pm_dims(pm_da_ds1d, pm_da_control1d, dim, comparison, metric):
+def test_compute_pm_dims(PM_da_ds_1d, PM_da_control_1d, dim, comparison, metric):
     """Test whether compute_pm calcs skill over all possible dims
     and comparisons and just reduces the result by dim."""
     actual = compute_perfect_model(
-        pm_da_ds1d, pm_da_control1d, metric=metric, dim=dim, comparison=comparison
+        PM_da_ds_1d, PM_da_control_1d, metric=metric, dim=dim, comparison=comparison,
     )
     # change dim as automatically in compute functions for probabilistic
     if dim in ['init', ['init', 'member']] and metric in PROBABILISTIC_METRICS:
@@ -165,7 +141,7 @@ def test_compute_pm_dims(pm_da_ds1d, pm_da_control1d, dim, comparison, metric):
     elif isinstance(dim, str):
         dim = [dim]
     # check whether only dim got reduced from coords
-    assert set(pm_da_ds1d.dims) - set(actual.dims) == set(dim)
+    assert set(PM_da_ds_1d.dims) - set(actual.dims) == set(dim)
     # check whether all nan
     print(actual.dims, actual.coords, actual)
     assert not actual.isnull().any()
@@ -175,18 +151,22 @@ def test_compute_pm_dims(pm_da_ds1d, pm_da_control1d, dim, comparison, metric):
 @pytest.mark.parametrize('metric', ('rmse', 'crpss', 'crpss_es'))
 @pytest.mark.parametrize('dim', ('init', 'member'))
 def test_compute_hindcast_dims(
-    initialized_da, observations_da, dim, comparison, metric
+    hind_da_initialized_1d, observations_da_1d, dim, comparison, metric
 ):
     """Test whether compute_hindcast calcs skill over all possible dims
     and comparisons and just reduces the result by dim."""
     actual = compute_hindcast(
-        initialized_da, observations_da, metric=metric, dim=dim, comparison=comparison
+        hind_da_initialized_1d,
+        observations_da_1d,
+        metric=metric,
+        dim=dim,
+        comparison=comparison,
     )
     # change dim as automatically in compute functions for probabilistic
     if dim == 'init' and metric in PROBABILISTIC_METRICS:
         dim = 'member'
     # check whether only dim got reduced from coords
-    assert set(initialized_da.dims) - set(actual.dims) == set([dim])
+    assert set(hind_da_initialized_1d.dims) - set(actual.dims) == set([dim])
     # check whether all nan
     if 'init' in actual.dims:
         actual = actual.mean('init')

--- a/climpred/tests/test_compute_dims.py
+++ b/climpred/tests/test_compute_dims.py
@@ -12,12 +12,14 @@ from climpred.constants import (
 from climpred.prediction import compute_hindcast, compute_perfect_model
 from climpred.utils import get_comparison_class, get_metric_class
 
-bootstrap = 3
+BOOTSTRAP = 3
 
 
 @pytest.mark.parametrize('metric', ['crps', 'mse'])
 @pytest.mark.parametrize('comparison', PROBABILISTIC_PM_COMPARISONS)
-def test_pm_comparison_stack_dims_when_deterministic(PM_da_ds_1d, comparison, metric):
+def test_pm_comparison_stack_dims_when_deterministic(
+    PM_da_ds_1d, comparison, metric
+):
     metric = get_metric_class(metric, PM_METRICS)
     comparison = get_comparison_class(comparison, PM_COMPARISONS)
     actual_f, actual_r = comparison.function(PM_da_ds_1d, metric=metric)
@@ -77,7 +79,11 @@ def test_compute_perfect_model_different_dims_quite_close(
         dim=['init', 'member'],
     )
     stack_dims_false = compute_perfect_model(
-        PM_da_ds_1d, PM_da_control_1d, comparison='m2c', metric='rmse', dim='member',
+        PM_da_ds_1d,
+        PM_da_control_1d,
+        comparison='m2c',
+        metric='rmse',
+        dim='member',
     ).mean(['init'])
     # no more than 10% difference
     assert_allclose(stack_dims_true, stack_dims_false, rtol=0.1, atol=0.03)
@@ -92,7 +98,7 @@ def test_bootstrap_pm_dim(PM_da_ds_1d, PM_da_control_1d):
         metric='rmse',
         dim='member',
         comparison='m2c',
-        bootstrap=bootstrap,
+        bootstrap=BOOTSTRAP,
     )
     assert 'init' in actual.dims
     for kind in ['init', 'uninit']:
@@ -115,7 +121,7 @@ def test_bootstrap_hindcast_dim(
         metric='rmse',
         dim='member',
         comparison='m2o',
-        bootstrap=bootstrap,
+        bootstrap=BOOTSTRAP,
     )
     assert 'init' in actual.dims
     for kind in ['init', 'uninit']:
@@ -129,11 +135,17 @@ def test_bootstrap_hindcast_dim(
 @pytest.mark.parametrize('metric', ('rmse', 'crpss'))
 @pytest.mark.parametrize('comparison', PROBABILISTIC_PM_COMPARISONS)
 @pytest.mark.parametrize('dim', ('init', 'member', ['init', 'member']))
-def test_compute_pm_dims(PM_da_ds_1d, PM_da_control_1d, dim, comparison, metric):
+def test_compute_pm_dims(
+    PM_da_ds_1d, PM_da_control_1d, dim, comparison, metric
+):
     """Test whether compute_pm calcs skill over all possible dims
     and comparisons and just reduces the result by dim."""
     actual = compute_perfect_model(
-        PM_da_ds_1d, PM_da_control_1d, metric=metric, dim=dim, comparison=comparison,
+        PM_da_ds_1d,
+        PM_da_control_1d,
+        metric=metric,
+        dim=dim,
+        comparison=comparison,
     )
     # change dim as automatically in compute functions for probabilistic
     if dim in ['init', ['init', 'member']] and metric in PROBABILISTIC_METRICS:

--- a/climpred/tests/test_compute_dims.py
+++ b/climpred/tests/test_compute_dims.py
@@ -18,11 +18,11 @@ BOOTSTRAP = 3
 @pytest.mark.parametrize('metric', ['crps', 'mse'])
 @pytest.mark.parametrize('comparison', PROBABILISTIC_PM_COMPARISONS)
 def test_pm_comparison_stack_dims_when_deterministic(
-    PM_da_ds_1d, comparison, metric
+    PM_da_initialized_1d, comparison, metric
 ):
     metric = get_metric_class(metric, PM_METRICS)
     comparison = get_comparison_class(comparison, PM_COMPARISONS)
-    actual_f, actual_r = comparison.function(PM_da_ds_1d, metric=metric)
+    actual_f, actual_r = comparison.function(PM_da_initialized_1d, metric=metric)
     if not metric.probabilistic:
         assert 'member' in actual_f.dims
         assert 'member' in actual_r.dims
@@ -34,11 +34,11 @@ def test_pm_comparison_stack_dims_when_deterministic(
 # cannot work for e2c, m2e comparison because only 1:1 comparison
 @pytest.mark.parametrize('comparison', PROBABILISTIC_PM_COMPARISONS)
 def test_compute_perfect_model_dim_over_member(
-    PM_da_ds_1d, PM_da_control_1d, comparison
+    PM_da_initialized_1d, PM_da_control_1d, comparison
 ):
     """Test deterministic metric calc skill over member dim."""
     actual = compute_perfect_model(
-        PM_da_ds_1d,
+        PM_da_initialized_1d,
         PM_da_control_1d,
         comparison=comparison,
         metric='rmse',
@@ -67,19 +67,19 @@ def test_compute_hindcast_dim_over_member(
 
 
 def test_compute_perfect_model_different_dims_quite_close(
-    PM_da_ds_1d, PM_da_control_1d
+    PM_da_initialized_1d, PM_da_control_1d
 ):
     """Test whether dim=['init','member'] and
     dim='member' results."""
     stack_dims_true = compute_perfect_model(
-        PM_da_ds_1d,
+        PM_da_initialized_1d,
         PM_da_control_1d,
         comparison='m2c',
         metric='rmse',
         dim=['init', 'member'],
     )
     stack_dims_false = compute_perfect_model(
-        PM_da_ds_1d,
+        PM_da_initialized_1d,
         PM_da_control_1d,
         comparison='m2c',
         metric='rmse',
@@ -89,11 +89,11 @@ def test_compute_perfect_model_different_dims_quite_close(
     assert_allclose(stack_dims_true, stack_dims_false, rtol=0.1, atol=0.03)
 
 
-def test_bootstrap_pm_dim(PM_da_ds_1d, PM_da_control_1d):
+def test_bootstrap_pm_dim(PM_da_initialized_1d, PM_da_control_1d):
     """Test whether bootstrap_hindcast calcs skill over member dim and
     returns init dim."""
     actual = bootstrap_perfect_model(
-        PM_da_ds_1d,
+        PM_da_initialized_1d,
         PM_da_control_1d,
         metric='rmse',
         dim='member',
@@ -136,12 +136,12 @@ def test_bootstrap_hindcast_dim(
 @pytest.mark.parametrize('comparison', PROBABILISTIC_PM_COMPARISONS)
 @pytest.mark.parametrize('dim', ('init', 'member', ['init', 'member']))
 def test_compute_pm_dims(
-    PM_da_ds_1d, PM_da_control_1d, dim, comparison, metric
+    PM_da_initialized_1d, PM_da_control_1d, dim, comparison, metric
 ):
     """Test whether compute_pm calcs skill over all possible dims
     and comparisons and just reduces the result by dim."""
     actual = compute_perfect_model(
-        PM_da_ds_1d,
+        PM_da_initialized_1d,
         PM_da_control_1d,
         metric=metric,
         dim=dim,
@@ -153,7 +153,7 @@ def test_compute_pm_dims(
     elif isinstance(dim, str):
         dim = [dim]
     # check whether only dim got reduced from coords
-    assert set(PM_da_ds_1d.dims) - set(actual.dims) == set(dim)
+    assert set(PM_da_initialized_1d.dims) - set(actual.dims) == set(dim)
     # check whether all nan
     print(actual.dims, actual.coords, actual)
     assert not actual.isnull().any()

--- a/climpred/tests/test_demo_data.py
+++ b/climpred/tests/test_demo_data.py
@@ -16,3 +16,8 @@ def test_open_dataset_locally(filepath):
 def test_load_datasets_empty():
     actual = load_dataset()
     assert actual is None
+
+
+@pytest.mark.parametrize('cache', [False, True])
+def test_load_dataset_cache(cache):
+    load_dataset(cache=cache)

--- a/climpred/tests/test_effective_p_value.py
+++ b/climpred/tests/test_effective_p_value.py
@@ -2,145 +2,125 @@ import pytest
 
 from climpred.constants import HINDCAST_COMPARISONS, PM_COMPARISONS
 from climpred.prediction import compute_hindcast, compute_perfect_model
-from climpred.tutorial import load_dataset
 
 
-@pytest.fixture
-def hindcast():
-    da = load_dataset('CESM-DP-SST')
-    da = da['SST']
-    return da
-
-
-@pytest.fixture
-def reconstruction():
-    da = load_dataset('FOSI-SST')
-    da = da['SST']
-    return da
-
-
-@pytest.fixture
-def perfect_model():
-    da = load_dataset('MPI-PM-DP-1D')
-    da = da.sel(area='global', period='ym')['tos']
-    return da
-
-
-@pytest.fixture
-def perfect_model_control():
-    da = load_dataset('MPI-control-1D')
-    da = da.sel(area='global', period='ym')['tos']
-    return da
-
-
-@pytest.mark.parametrize('comparison', HINDCAST_COMPARISONS)
-def test_eff_sample_size_smaller_than_n_hindcast(hindcast, reconstruction, comparison):
-    """Tests that effective sample size is less than or equal to the actual sample size
-    of the data."""
-    N = hindcast.mean('member').count('init')
-    eff_N = compute_hindcast(hindcast, reconstruction, metric='eff_n', max_dof=True)
-    assert (eff_N <= N).all()
-
-
-@pytest.mark.parametrize('comparison', PM_COMPARISONS)
-def test_eff_sample_size_smaller_than_n_perfect_model(
-    perfect_model, perfect_model_control, comparison
+@pytest.mark.parametrize("comparison", HINDCAST_COMPARISONS)
+def test_eff_sample_size_smaller_than_n_hind_da_initialized_1d(
+    hind_da_initialized_1d, reconstruction_da_1d, comparison
 ):
     """Tests that effective sample size is less than or equal to the actual sample size
     of the data."""
-    if comparison == 'e2c':
-        N = perfect_model.mean('member').count('init')
+    N = hind_da_initialized_1d.mean("member").count("init")
+    eff_N = compute_hindcast(
+        hind_da_initialized_1d,
+        reconstruction_da_1d,
+        metric="eff_n",
+        max_dof=True,
+    )
+    assert (eff_N <= N).all()
+
+
+@pytest.mark.parametrize("comparison", PM_COMPARISONS)
+def test_eff_sample_size_smaller_than_n_PM_da_ds_1d(
+    PM_da_ds_1d, PM_da_control_1d, comparison
+):
+    """Tests that effective sample size is less than or equal to the actual sample size
+    of the data."""
+    if comparison == "e2c":
+        N = PM_da_ds_1d.mean("member").count("init")
     else:
-        N = perfect_model.stack(stack_dims=['init', 'member']).count('stack_dims')
+        N = PM_da_ds_1d.stack(stack_dims=["init", "member"]).count(
+            "stack_dims"
+        )
     eff_N = compute_perfect_model(
-        perfect_model, perfect_model_control, metric='eff_n', comparison=comparison,
+        PM_da_ds_1d, PM_da_control_1d, metric="eff_n", comparison=comparison,
     )
     assert (eff_N <= N).all()
 
 
-@pytest.mark.parametrize('comparison', HINDCAST_COMPARISONS)
-def test_eff_pearson_p_greater_or_equal_to_normal_p_hindcast(
-    hindcast, reconstruction, comparison
+@pytest.mark.parametrize("comparison", HINDCAST_COMPARISONS)
+def test_eff_pearson_p_greater_or_equal_to_normal_p_hind_da_initialized_1d(
+    hind_da_initialized_1d, reconstruction_da_1d, comparison
 ):
     """Tests that the Pearson effective p value (more conservative) is greater than or
     equal to the standard p value."""
     normal_p = compute_hindcast(
-        hindcast,
-        reconstruction,
-        metric='pearson_r_p_value',
+        hind_da_initialized_1d,
+        reconstruction_da_1d,
+        metric="pearson_r_p_value",
         max_dof=True,
         comparison=comparison,
     )
     eff_p = compute_hindcast(
-        hindcast,
-        reconstruction,
-        metric='pearson_r_eff_p_value',
+        hind_da_initialized_1d,
+        reconstruction_da_1d,
+        metric="pearson_r_eff_p_value",
         max_dof=True,
         comparison=comparison,
     )
     assert (normal_p <= eff_p).all()
 
 
-@pytest.mark.parametrize('comparison', PM_COMPARISONS)
+@pytest.mark.parametrize("comparison", PM_COMPARISONS)
 def test_eff_pearson_p_greater_or_equal_to_normal_p_pm(
-    perfect_model, perfect_model_control, comparison
+    PM_da_ds_1d, PM_da_control_1d, comparison
 ):
     """Tests that the Pearson effective p value (more conservative) is greater than or
     equal to the standard p value."""
     normal_p = compute_perfect_model(
-        perfect_model,
-        perfect_model_control,
-        metric='pearson_r_p_value',
+        PM_da_ds_1d,
+        PM_da_control_1d,
+        metric="pearson_r_p_value",
         comparison=comparison,
     )
     eff_p = compute_perfect_model(
-        perfect_model,
-        perfect_model_control,
-        metric='pearson_r_eff_p_value',
+        PM_da_ds_1d,
+        PM_da_control_1d,
+        metric="pearson_r_eff_p_value",
         comparison=comparison,
     )
     assert (normal_p <= eff_p).all()
 
 
-@pytest.mark.parametrize('comparison', HINDCAST_COMPARISONS)
-def test_eff_spearman_p_greater_or_equal_to_normal_p_hindcast(
-    hindcast, reconstruction, comparison
+@pytest.mark.parametrize("comparison", HINDCAST_COMPARISONS)
+def test_eff_spearman_p_greater_or_equal_to_normal_p_hind_da_initialized_1d(
+    hind_da_initialized_1d, reconstruction_da_1d, comparison
 ):
     """Tests that the Pearson effective p value (more conservative) is greater than or
     equal to the standard p value."""
     normal_p = compute_hindcast(
-        hindcast,
-        reconstruction,
-        metric='spearman_r_p_value',
+        hind_da_initialized_1d,
+        reconstruction_da_1d,
+        metric="spearman_r_p_value",
         max_dof=True,
         comparison=comparison,
     )
     eff_p = compute_hindcast(
-        hindcast,
-        reconstruction,
-        metric='spearman_r_eff_p_value',
+        hind_da_initialized_1d,
+        reconstruction_da_1d,
+        metric="spearman_r_eff_p_value",
         max_dof=True,
         comparison=comparison,
     )
     assert (normal_p <= eff_p).all()
 
 
-@pytest.mark.parametrize('comparison', PM_COMPARISONS)
+@pytest.mark.parametrize("comparison", PM_COMPARISONS)
 def test_eff_spearman_p_greater_or_equal_to_normal_p_pm(
-    perfect_model, perfect_model_control, comparison
+    PM_da_ds_1d, PM_da_control_1d, comparison
 ):
     """Tests that the Pearson effective p value (more conservative) is greater than or
     equal to the standard p value."""
     normal_p = compute_perfect_model(
-        perfect_model,
-        perfect_model_control,
-        metric='spearman_r_p_value',
+        PM_da_ds_1d,
+        PM_da_control_1d,
+        metric="spearman_r_p_value",
         comparison=comparison,
     )
     eff_p = compute_perfect_model(
-        perfect_model,
-        perfect_model_control,
-        metric='spearman_r_eff_p_value',
+        PM_da_ds_1d,
+        PM_da_control_1d,
+        metric="spearman_r_eff_p_value",
         comparison=comparison,
     )
     assert (normal_p <= eff_p).all()

--- a/climpred/tests/test_effective_p_value.py
+++ b/climpred/tests/test_effective_p_value.py
@@ -18,17 +18,19 @@ def test_eff_sample_size_smaller_than_n_hind_da_initialized_1d(
 
 
 @pytest.mark.parametrize('comparison', PM_COMPARISONS)
-def test_eff_sample_size_smaller_than_n_PM_da_ds_1d(
-    PM_da_ds_1d, PM_da_control_1d, comparison
+def test_eff_sample_size_smaller_than_n_PM_da_initialized_1d(
+    PM_da_initialized_1d, PM_da_control_1d, comparison
 ):
     """Tests that effective sample size is less than or equal to the actual sample size
     of the data."""
     if comparison == 'e2c':
-        N = PM_da_ds_1d.mean('member').count('init')
+        N = PM_da_initialized_1d.mean('member').count('init')
     else:
-        N = PM_da_ds_1d.stack(stack_dims=['init', 'member']).count('stack_dims')
+        N = PM_da_initialized_1d.stack(stack_dims=['init', 'member']).count(
+            'stack_dims'
+        )
     eff_N = compute_perfect_model(
-        PM_da_ds_1d, PM_da_control_1d, metric='eff_n', comparison=comparison,
+        PM_da_initialized_1d, PM_da_control_1d, metric='eff_n', comparison=comparison,
     )
     assert (eff_N <= N).all()
 
@@ -58,18 +60,18 @@ def test_eff_pearson_p_greater_or_equal_to_normal_p_hind_da_initialized_1d(
 
 @pytest.mark.parametrize('comparison', PM_COMPARISONS)
 def test_eff_pearson_p_greater_or_equal_to_normal_p_pm(
-    PM_da_ds_1d, PM_da_control_1d, comparison
+    PM_da_initialized_1d, PM_da_control_1d, comparison
 ):
     """Tests that the Pearson effective p value (more conservative) is greater than or
     equal to the standard p value."""
     normal_p = compute_perfect_model(
-        PM_da_ds_1d,
+        PM_da_initialized_1d,
         PM_da_control_1d,
         metric='pearson_r_p_value',
         comparison=comparison,
     )
     eff_p = compute_perfect_model(
-        PM_da_ds_1d,
+        PM_da_initialized_1d,
         PM_da_control_1d,
         metric='pearson_r_eff_p_value',
         comparison=comparison,
@@ -102,18 +104,18 @@ def test_eff_spearman_p_greater_or_equal_to_normal_p_hind_da_initialized_1d(
 
 @pytest.mark.parametrize('comparison', PM_COMPARISONS)
 def test_eff_spearman_p_greater_or_equal_to_normal_p_pm(
-    PM_da_ds_1d, PM_da_control_1d, comparison
+    PM_da_initialized_1d, PM_da_control_1d, comparison
 ):
     """Tests that the Pearson effective p value (more conservative) is greater than or
     equal to the standard p value."""
     normal_p = compute_perfect_model(
-        PM_da_ds_1d,
+        PM_da_initialized_1d,
         PM_da_control_1d,
         metric='spearman_r_p_value',
         comparison=comparison,
     )
     eff_p = compute_perfect_model(
-        PM_da_ds_1d,
+        PM_da_initialized_1d,
         PM_da_control_1d,
         metric='spearman_r_eff_p_value',
         comparison=comparison,

--- a/climpred/tests/test_effective_p_value.py
+++ b/climpred/tests/test_effective_p_value.py
@@ -4,41 +4,36 @@ from climpred.constants import HINDCAST_COMPARISONS, PM_COMPARISONS
 from climpred.prediction import compute_hindcast, compute_perfect_model
 
 
-@pytest.mark.parametrize("comparison", HINDCAST_COMPARISONS)
+@pytest.mark.parametrize('comparison', HINDCAST_COMPARISONS)
 def test_eff_sample_size_smaller_than_n_hind_da_initialized_1d(
     hind_da_initialized_1d, reconstruction_da_1d, comparison
 ):
     """Tests that effective sample size is less than or equal to the actual sample size
     of the data."""
-    N = hind_da_initialized_1d.mean("member").count("init")
+    N = hind_da_initialized_1d.mean('member').count('init')
     eff_N = compute_hindcast(
-        hind_da_initialized_1d,
-        reconstruction_da_1d,
-        metric="eff_n",
-        max_dof=True,
+        hind_da_initialized_1d, reconstruction_da_1d, metric='eff_n', max_dof=True,
     )
     assert (eff_N <= N).all()
 
 
-@pytest.mark.parametrize("comparison", PM_COMPARISONS)
+@pytest.mark.parametrize('comparison', PM_COMPARISONS)
 def test_eff_sample_size_smaller_than_n_PM_da_ds_1d(
     PM_da_ds_1d, PM_da_control_1d, comparison
 ):
     """Tests that effective sample size is less than or equal to the actual sample size
     of the data."""
-    if comparison == "e2c":
-        N = PM_da_ds_1d.mean("member").count("init")
+    if comparison == 'e2c':
+        N = PM_da_ds_1d.mean('member').count('init')
     else:
-        N = PM_da_ds_1d.stack(stack_dims=["init", "member"]).count(
-            "stack_dims"
-        )
+        N = PM_da_ds_1d.stack(stack_dims=['init', 'member']).count('stack_dims')
     eff_N = compute_perfect_model(
-        PM_da_ds_1d, PM_da_control_1d, metric="eff_n", comparison=comparison,
+        PM_da_ds_1d, PM_da_control_1d, metric='eff_n', comparison=comparison,
     )
     assert (eff_N <= N).all()
 
 
-@pytest.mark.parametrize("comparison", HINDCAST_COMPARISONS)
+@pytest.mark.parametrize('comparison', HINDCAST_COMPARISONS)
 def test_eff_pearson_p_greater_or_equal_to_normal_p_hind_da_initialized_1d(
     hind_da_initialized_1d, reconstruction_da_1d, comparison
 ):
@@ -47,21 +42,21 @@ def test_eff_pearson_p_greater_or_equal_to_normal_p_hind_da_initialized_1d(
     normal_p = compute_hindcast(
         hind_da_initialized_1d,
         reconstruction_da_1d,
-        metric="pearson_r_p_value",
+        metric='pearson_r_p_value',
         max_dof=True,
         comparison=comparison,
     )
     eff_p = compute_hindcast(
         hind_da_initialized_1d,
         reconstruction_da_1d,
-        metric="pearson_r_eff_p_value",
+        metric='pearson_r_eff_p_value',
         max_dof=True,
         comparison=comparison,
     )
     assert (normal_p <= eff_p).all()
 
 
-@pytest.mark.parametrize("comparison", PM_COMPARISONS)
+@pytest.mark.parametrize('comparison', PM_COMPARISONS)
 def test_eff_pearson_p_greater_or_equal_to_normal_p_pm(
     PM_da_ds_1d, PM_da_control_1d, comparison
 ):
@@ -70,19 +65,19 @@ def test_eff_pearson_p_greater_or_equal_to_normal_p_pm(
     normal_p = compute_perfect_model(
         PM_da_ds_1d,
         PM_da_control_1d,
-        metric="pearson_r_p_value",
+        metric='pearson_r_p_value',
         comparison=comparison,
     )
     eff_p = compute_perfect_model(
         PM_da_ds_1d,
         PM_da_control_1d,
-        metric="pearson_r_eff_p_value",
+        metric='pearson_r_eff_p_value',
         comparison=comparison,
     )
     assert (normal_p <= eff_p).all()
 
 
-@pytest.mark.parametrize("comparison", HINDCAST_COMPARISONS)
+@pytest.mark.parametrize('comparison', HINDCAST_COMPARISONS)
 def test_eff_spearman_p_greater_or_equal_to_normal_p_hind_da_initialized_1d(
     hind_da_initialized_1d, reconstruction_da_1d, comparison
 ):
@@ -91,21 +86,21 @@ def test_eff_spearman_p_greater_or_equal_to_normal_p_hind_da_initialized_1d(
     normal_p = compute_hindcast(
         hind_da_initialized_1d,
         reconstruction_da_1d,
-        metric="spearman_r_p_value",
+        metric='spearman_r_p_value',
         max_dof=True,
         comparison=comparison,
     )
     eff_p = compute_hindcast(
         hind_da_initialized_1d,
         reconstruction_da_1d,
-        metric="spearman_r_eff_p_value",
+        metric='spearman_r_eff_p_value',
         max_dof=True,
         comparison=comparison,
     )
     assert (normal_p <= eff_p).all()
 
 
-@pytest.mark.parametrize("comparison", PM_COMPARISONS)
+@pytest.mark.parametrize('comparison', PM_COMPARISONS)
 def test_eff_spearman_p_greater_or_equal_to_normal_p_pm(
     PM_da_ds_1d, PM_da_control_1d, comparison
 ):
@@ -114,13 +109,13 @@ def test_eff_spearman_p_greater_or_equal_to_normal_p_pm(
     normal_p = compute_perfect_model(
         PM_da_ds_1d,
         PM_da_control_1d,
-        metric="spearman_r_p_value",
+        metric='spearman_r_p_value',
         comparison=comparison,
     )
     eff_p = compute_perfect_model(
         PM_da_ds_1d,
         PM_da_control_1d,
-        metric="spearman_r_eff_p_value",
+        metric='spearman_r_eff_p_value',
         comparison=comparison,
     )
     assert (normal_p <= eff_p).all()

--- a/climpred/tests/test_graphics.py
+++ b/climpred/tests/test_graphics.py
@@ -7,16 +7,19 @@ def test_mpi_pm_plot_bootstrapped_skill_over_leadyear():
     """
     Checks plots from bootstrap_perfect_model works.
     """
-    da = load_dataset('MPI-PM-DP-1D').isel(area=1, period=-1)
-    PM_da_ds1d = da['tos']
+    da = load_dataset("MPI-PM-DP-1D").isel(area=1, period=-1)
+    PM_da_ds1d = da["tos"]
 
-    da = load_dataset('MPI-control-1D').isel(area=1, period=-1)
-    PM_da_control1d = da['tos']
+    da = load_dataset("MPI-control-1D").isel(area=1, period=-1)
+    PM_da_control1d = da["tos"]
 
-    # sig = 95
-    bootstrap = 5
+    bootstrap = 3
     res = bootstrap_perfect_model(
-        PM_da_ds1d, PM_da_control1d, metric='pearson_r', dim='init', bootstrap=bootstrap
-    ).mean('member')
+        PM_da_ds1d,
+        PM_da_control1d,
+        metric="pearson_r",
+        dim="init",
+        bootstrap=bootstrap,
+    ).mean("member")
     res_ax = plot_bootstrapped_skill_over_leadyear(res, 95)
     assert res_ax is not None

--- a/climpred/tests/test_hindcastEnsemble_class.py
+++ b/climpred/tests/test_hindcastEnsemble_class.py
@@ -1,178 +1,116 @@
-import numpy as np
 import pytest
 
 from climpred import HindcastEnsemble
-from climpred.tutorial import load_dataset
 
 
-@pytest.fixture
-def initialized_ds():
-    da = load_dataset('CESM-DP-SST')
-    return da
-
-
-@pytest.fixture
-def initialized_da():
-    da = load_dataset('CESM-DP-SST')['SST']
-    da = da.sel(init=slice(1955, 2015))
-    da = da - da.mean('init')
-    return da
-
-
-@pytest.fixture
-def fosi_3d():
-    ds = load_dataset('FOSI-SST-3D')
-    return ds
-
-
-@pytest.fixture
-def dple_3d():
-    ds = load_dataset('CESM-DP-SST-3D')
-    return ds
-
-
-@pytest.fixture
-def observations_ds():
-    da = load_dataset('ERSST')
-    return da
-
-
-@pytest.fixture
-def reconstruction_ds():
-    da = load_dataset('FOSI-SST')
-    # same timeframe as DPLE
-    return da
-
-
-@pytest.fixture
-def uninitialized_ds():
-    da = load_dataset('CESM-LE')
-    # add member coordinate
-    da['member'] = np.arange(1, 1 + da.member.size)
-    return da
-
-
-@pytest.fixture
-def uninitialized_da():
-    da = load_dataset('CESM-LE')['SST']
-    # add member coordinate
-    da['member'] = np.arange(1, 1 + da.member.size)
-    da = da - da.mean('time')
-    return da
-
-
-@pytest.fixture
-def observations_da():
-    da = load_dataset('ERSST')['SST']
-    da = da - da.mean('time')
-    return da
-
-
-def test_hindcastEnsemble_init(initialized_ds):
+def test_hindcastEnsemble_init(hind_ds_initialized_1d):
     """Test to see hindcast ensemble can be initialized"""
-    hindcast = HindcastEnsemble(initialized_ds)
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
     print(hindcast)
     assert hindcast
 
 
-def test_hindcastEnsemble_init_da(initialized_da):
+def test_hindcastEnsemble_init_da(hind_da_initialized_1d):
     """Test to see hindcast ensemble can be initialized with da"""
-    hindcast = HindcastEnsemble(initialized_da)
+    hindcast = HindcastEnsemble(hind_da_initialized_1d)
     assert hindcast
 
 
-def test_add_reference(initialized_ds, reconstruction_ds):
+def test_add_reference(hind_ds_initialized_1d, reconstruction_ds_1d):
     """Test to see if a reference can be added to the HindcastEnsemble"""
     # TODO: This should be removed once `add_reference` is deprecated.
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_reference(reconstruction_ds, 'reconstruction')
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_reference(reconstruction_ds_1d, 'reconstruction')
     # Will fail if this comes back empty.
     assert hindcast.get_reference()
 
 
-def test_add_reference_da(initialized_ds, observations_da):
+def test_add_reference_da(hind_ds_initialized_1d, observations_da_1d):
     """Test to see if a reference can be added to the HindcastEnsemble as a da"""
     # TODO: This should be removed once `add_reference` is deprecated.
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_reference(observations_da, 'observations')
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_reference(observations_da_1d, 'observations')
     assert hindcast.get_reference()
 
 
-def test_add_reference_deprecated(initialized_ds, observations_da):
+def test_add_reference_deprecated(hind_ds_initialized_1d, observations_da_1d):
     """Tests that deprecation warning is thrown for add_reference method."""
-    hindcast = HindcastEnsemble(initialized_ds)
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
     with pytest.warns(PendingDeprecationWarning) as record:
-        hindcast = hindcast.add_reference(observations_da, 'observations')
+        hindcast = hindcast.add_reference(observations_da_1d, 'observations')
     assert 'deprecated' in record[0].message.args[0]
 
 
-def test_add_observations(initialized_ds, reconstruction_ds):
+def test_add_observations(hind_ds_initialized_1d, reconstruction_ds_1d):
     """Test to see if observations can be added to the HindcastEnsemble"""
     # NOTE: This should be removed once `add_reference` is deprecated.
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_observations(reconstruction_ds, 'reconstruction')
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_observations(reconstruction_ds_1d, 'reconstruction')
     # Will fail if this comes back empty.
     assert hindcast.get_observations()
 
 
-def test_add_observations_da(initialized_ds, observations_da):
+def test_add_observations_da_1d(hind_ds_initialized_1d, observations_da_1d):
     """Test to see if observations can be added to the HindcastEnsemble as a da"""
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_observations(observations_da, 'observations')
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_observations(observations_da_1d, 'observations')
     assert hindcast.get_observations()
 
 
-def test_add_uninitialized(initialized_ds, uninitialized_ds):
+def test_add_uninitialized(hind_ds_initialized_1d, hind_ds_uninitialized_1d):
     """Test to see if an uninitialized ensemble can be added to the HindcastEnsemble"""
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_uninitialized(uninitialized_ds)
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_uninitialized(hind_ds_uninitialized_1d)
     assert hindcast.get_uninitialized()
 
 
-def test_add_uninitialized_da(initialized_ds, uninitialized_da):
+def test_add_hind_da_uninitialized_1d(hind_ds_initialized_1d, hind_da_uninitialized_1d):
     """Test to see if da uninitialized ensemble can be added to the HindcastEnsemble"""
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_uninitialized(uninitialized_da)
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_uninitialized(hind_da_uninitialized_1d)
     assert hindcast.get_uninitialized()
 
 
-def test_compute_metric(initialized_ds, reconstruction_ds, observations_ds):
+def test_compute_metric(
+    hind_ds_initialized_1d, reconstruction_ds_1d, observations_ds_1d
+):
     """Test to see if compute_metric can be run from the HindcastEnsemble"""
     # TODO: Remove this test after deprecating `compute_metric()`
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_observations(reconstruction_ds, 'reconstruction')
-    hindcast = hindcast.add_observations(observations_ds, 'observations')
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_observations(reconstruction_ds_1d, 'reconstruction')
+    hindcast = hindcast.add_observations(observations_ds_1d, 'observations')
     # Don't need to check for NaNs, etc. since that's handled in the prediction
     # module testing.
     hindcast.compute_metric()  # compute over all observations
-    hindcast.compute_metric('reconstruction')  # compute over single observation
+    # compute over single observation
+    hindcast.compute_metric('reconstruction')
     # test all keywords
     hindcast.compute_metric(max_dof=True, metric='rmse', comparison='m2o')
 
 
-def test_compute_metric_single(initialized_ds, reconstruction_ds):
+def test_compute_metric_single(hind_ds_initialized_1d, reconstruction_ds_1d):
     """Test to see if compute_metric automatically works with a single observational
     product."""
     # TODO: Remove this test after deprecating `compute_metric()`
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_observations(reconstruction_ds, 'reconstruction')
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_observations(reconstruction_ds_1d, 'reconstruction')
     hindcast.compute_metric()
 
 
-def test_compute_metric_deprecated(initialized_ds, reconstruction_ds):
+def test_compute_metric_deprecated(hind_ds_initialized_1d, reconstruction_ds_1d):
     """Tests that deprecation warning is thrown for compute_metric method."""
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_observations(reconstruction_ds, 'reconstruction')
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_observations(reconstruction_ds_1d, 'reconstruction')
     with pytest.warns(PendingDeprecationWarning) as record:
         hindcast = hindcast.compute_metric()
     assert 'deprecated' in record[0].message.args[0]
 
 
-def test_verify(initialized_ds, reconstruction_ds, observations_ds):
+def test_verify(hind_ds_initialized_1d, reconstruction_ds_1d, observations_ds_1d):
     """Test to see if verify can be run from the HindcastEnsemble"""
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_observations(reconstruction_ds, 'reconstruction')
-    hindcast = hindcast.add_observations(observations_ds, 'observations')
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_observations(reconstruction_ds_1d, 'reconstruction')
+    hindcast = hindcast.add_observations(observations_ds_1d, 'observations')
     # Don't need to check for NaNs, etc. since that's handled in the prediction
     # module testing.
     hindcast.verify()  # compute over all observations
@@ -181,24 +119,27 @@ def test_verify(initialized_ds, reconstruction_ds, observations_ds):
     hindcast.verify(max_dof=True, metric='rmse', comparison='m2o')
 
 
-def test_verify_single(initialized_ds, reconstruction_ds):
+def test_verify_single(hind_ds_initialized_1d, reconstruction_ds_1d):
     """Test to see if verify automatically works with a single observational
     product."""
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_observations(reconstruction_ds, 'reconstruction')
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_observations(reconstruction_ds_1d, 'reconstruction')
     hindcast.verify()
 
 
 def test_compute_uninitialized(
-    initialized_ds, uninitialized_ds, reconstruction_ds, observations_ds
+    hind_ds_initialized_1d,
+    hind_ds_uninitialized_1d,
+    reconstruction_ds_1d,
+    observations_ds_1d,
 ):
     """Test to see if compute_uninitialized can be frun from the HindcastEnsemble"""
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_observations(reconstruction_ds, 'reconstruction')
-    hindcast = hindcast.add_uninitialized(uninitialized_ds)
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_observations(reconstruction_ds_1d, 'reconstruction')
+    hindcast = hindcast.add_uninitialized(hind_ds_uninitialized_1d)
     # single observations, no declaration of name.
     hindcast.compute_uninitialized()
-    hindcast = hindcast.add_observations(observations_ds, 'observations')
+    hindcast = hindcast.add_observations(observations_ds_1d, 'observations')
     # multiple observations, no name declaration.
     hindcast.compute_uninitialized()
     # multiple observations, call one.
@@ -206,23 +147,27 @@ def test_compute_uninitialized(
     hindcast.compute_uninitialized(metric='rmse', comparison='m2o')
 
 
-def test_compute_persistence(initialized_ds, reconstruction_ds, observations_ds):
+def test_compute_persistence(
+    hind_ds_initialized_1d, reconstruction_ds_1d, observations_ds_1d
+):
     """Test to see if compute_persistence can be run from the HindcastEnsemble"""
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_observations(reconstruction_ds, 'reconstruction')
-    hindcast = hindcast.add_observations(observations_ds, 'observations')
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_observations(reconstruction_ds_1d, 'reconstruction')
+    hindcast = hindcast.add_observations(observations_ds_1d, 'observations')
     hindcast.compute_persistence()
     hindcast.compute_persistence('observations')
     hindcast.compute_persistence(metric='rmse')
 
 
-def test_smooth_goddard(fosi_3d, dple_3d):
+def test_smooth_goddard(reconstruction_ds_3d, hind_ds_initialized_3d):
     """Test whether goddard smoothing function reduces ntime."""
-    hindcast = HindcastEnsemble(dple_3d.isel(nlat=slice(1, None)))
+    hindcast = HindcastEnsemble(hind_ds_initialized_3d.isel(nlat=slice(1, None)))
     hindcast = hindcast.add_observations(
-        fosi_3d.isel(nlat=slice(1, None)), 'reconstruction'
+        reconstruction_ds_3d.isel(nlat=slice(1, None)), 'reconstruction'
     )
-    hindcast = hindcast.add_uninitialized(fosi_3d.isel(nlat=slice(1, None)))
+    hindcast = hindcast.add_uninitialized(
+        reconstruction_ds_3d.isel(nlat=slice(1, None))
+    )
     initialized_before = hindcast._datasets['initialized']
     hindcast = hindcast.smooth(smooth_kws='goddard2013')
     actual_initialized = hindcast._datasets['initialized']
@@ -232,11 +177,11 @@ def test_smooth_goddard(fosi_3d, dple_3d):
         assert actual_initialized[dim[1:]].size < initialized_before[dim].size
 
 
-def test_smooth_coarsen(fosi_3d, dple_3d):
+def test_smooth_coarsen(reconstruction_ds_3d, hind_ds_initialized_3d):
     """Test whether coarsening reduces dim.size."""
-    hindcast = HindcastEnsemble(dple_3d)
-    hindcast = hindcast.add_observations(fosi_3d, 'reconstruction')
-    hindcast = hindcast.add_uninitialized(fosi_3d)
+    hindcast = HindcastEnsemble(hind_ds_initialized_3d)
+    hindcast = hindcast.add_observations(reconstruction_ds_3d, 'reconstruction')
+    hindcast = hindcast.add_uninitialized(reconstruction_ds_3d)
     initialized_before = hindcast._datasets['initialized']
     dim = 'nlon'
     hindcast = hindcast.smooth(smooth_kws={dim: 2})
@@ -244,11 +189,11 @@ def test_smooth_coarsen(fosi_3d, dple_3d):
     assert initialized_before[dim].size // 2 == actual_initialized[dim].size
 
 
-def test_smooth_temporal(fosi_3d, dple_3d):
+def test_smooth_temporal(reconstruction_ds_3d, hind_ds_initialized_3d):
     """Test whether coarsening reduces dim.size."""
-    hindcast = HindcastEnsemble(dple_3d)
-    hindcast = hindcast.add_observations(fosi_3d, 'reconstruction')
-    hindcast = hindcast.add_uninitialized(fosi_3d)
+    hindcast = HindcastEnsemble(hind_ds_initialized_3d)
+    hindcast = hindcast.add_observations(reconstruction_ds_3d, 'reconstruction')
+    hindcast = hindcast.add_uninitialized(reconstruction_ds_3d)
     initialized_before = hindcast._datasets['initialized']
     dim = 'lead'
     hindcast = hindcast.smooth(smooth_kws={dim: 4})
@@ -256,35 +201,35 @@ def test_smooth_temporal(fosi_3d, dple_3d):
     assert initialized_before[dim].size > actual_initialized[dim].size
 
 
-def test_isel_xarray_func(initialized_ds, reconstruction_ds):
+def test_isel_xarray_func(hind_ds_initialized_1d, reconstruction_ds_1d):
     """Test whether applying isel to the objects works."""
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_observations(reconstruction_ds, 'FOSI')
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_observations(reconstruction_ds_1d, 'FOSI')
     hindcast = hindcast.isel(lead=0, init=slice(0, 3)).isel(time=slice(5, 10))
     assert hindcast.get_initialized().init.size == 3
     assert hindcast.get_initialized().lead.size == 1
     assert hindcast.get_observations('FOSI').time.size == 5
 
 
-def test_get_initialized(initialized_ds):
+def test_get_initialized(hind_ds_initialized_1d):
     """Test whether get_initialized method works."""
-    hindcast = HindcastEnsemble(initialized_ds)
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
     init = hindcast.get_initialized()
     assert init == hindcast._datasets['initialized']
 
 
-def test_get_uninitialized(initialized_ds, uninitialized_ds):
+def test_get_uninitialized(hind_ds_initialized_1d, hind_ds_uninitialized_1d):
     """Test whether get_uninitialized method works."""
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_uninitialized(uninitialized_ds)
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_uninitialized(hind_ds_uninitialized_1d)
     uninit = hindcast.get_uninitialized()
     assert uninit == hindcast._datasets['uninitialized']
 
 
-def test_get_reference(initialized_ds, reconstruction_ds):
+def test_get_reference(hind_ds_initialized_1d, reconstruction_ds_1d):
     """Tests whether get_reference method works."""
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_reference(reconstruction_ds, 'FOSI')
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_reference(reconstruction_ds_1d, 'FOSI')
     # Without name keyword.
     ref = hindcast.get_reference()
     assert ref == hindcast._datasets['observations']['FOSI']
@@ -293,19 +238,19 @@ def test_get_reference(initialized_ds, reconstruction_ds):
     assert ref == hindcast._datasets['observations']['FOSI']
 
 
-def test_get_reference_deprecated(initialized_ds, reconstruction_ds):
+def test_get_reference_deprecated(hind_ds_initialized_1d, reconstruction_ds_1d):
     """Tests that deprecation warning is thrown for get_reference method."""
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_reference(reconstruction_ds, 'FOSI')
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_reference(reconstruction_ds_1d, 'FOSI')
     with pytest.warns(PendingDeprecationWarning) as record:
         hindcast = hindcast.get_reference()
     assert 'deprecated' in record[0].message.args[0]
 
 
-def test_get_observations(initialized_ds, reconstruction_ds):
+def test_get_observations(hind_ds_initialized_1d, reconstruction_ds_1d):
     """Tests whether get_observations method works."""
-    hindcast = HindcastEnsemble(initialized_ds)
-    hindcast = hindcast.add_observations(reconstruction_ds, 'FOSI')
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_observations(reconstruction_ds_1d, 'FOSI')
     # Without name keyword.
     obs = hindcast.get_observations()
     assert obs == hindcast._datasets['observations']['FOSI']
@@ -314,16 +259,18 @@ def test_get_observations(initialized_ds, reconstruction_ds):
     assert obs == hindcast._datasets['observations']['FOSI']
 
 
-def test_inplace(initialized_ds, reconstruction_ds, uninitialized_ds):
+def test_inplace(
+    hind_ds_initialized_1d, reconstruction_ds_1d, hind_ds_uninitialized_1d
+):
     """Tests that inplace operations do not work."""
-    hindcast = HindcastEnsemble(initialized_ds)
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
     # Adding observations.
-    hindcast.add_observations(reconstruction_ds, 'FOSI')
-    with_obs = hindcast.add_observations(reconstruction_ds, 'FOSI')
+    hindcast.add_observations(reconstruction_ds_1d, 'FOSI')
+    with_obs = hindcast.add_observations(reconstruction_ds_1d, 'FOSI')
     assert hindcast != with_obs
     # Adding an uninitialized ensemble.
-    hindcast.add_uninitialized(uninitialized_ds)
-    with_uninit = hindcast.add_uninitialized(uninitialized_ds)
+    hindcast.add_uninitialized(hind_ds_uninitialized_1d)
+    with_uninit = hindcast.add_uninitialized(hind_ds_uninitialized_1d)
     assert hindcast != with_uninit
     # Applying arbitrary func.
     hindcast.sum('init')

--- a/climpred/tests/test_hindcast_prediction.py
+++ b/climpred/tests/test_hindcast_prediction.py
@@ -1,5 +1,4 @@
 import dask
-import numpy as np
 import pytest
 
 from climpred.bootstrap import bootstrap_hindcast
@@ -13,104 +12,20 @@ from climpred.prediction import (
     compute_persistence,
     compute_uninitialized,
 )
-from climpred.tutorial import load_dataset
 
 # uacc is sqrt(MSSS), fails when MSSS negative
 DETERMINISTIC_HINDCAST_METRICS.remove('uacc')
 
 
-@pytest.fixture
-def initialized_ds():
-    da = load_dataset('CESM-DP-SST')
-    da = da - da.mean('init')
-    return da
-
-
-@pytest.fixture
-def initialized_ds_lead0():
-    da = load_dataset('CESM-DP-SST')
-    da = da - da.mean('init')
-    # Change to a lead-0 framework
-    da['init'] += 1
-    da['lead'] -= 1
-    return da
-
-
-@pytest.fixture
-def initialized_da():
-    da = load_dataset('CESM-DP-SST')['SST']
-    da = da - da.mean('init')
-    return da
-
-
-@pytest.fixture
-def observations_ds():
-    da = load_dataset('ERSST')
-    da = da - da.mean('time')
-    return da
-
-
-@pytest.fixture
-def observations_da():
-    da = load_dataset('ERSST')['SST']
-    da = da - da.mean('time')
-    return da
-
-
-@pytest.fixture
-def reconstruction_ds():
-    da = load_dataset('FOSI-SST')
-    da = da - da.mean('time')
-    return da
-
-
-@pytest.fixture
-def reconstruction_da():
-    da = load_dataset('FOSI-SST')['SST']
-    da = da - da.mean('time')
-    return da
-
-
-@pytest.fixture
-def uninitialized_ds():
-    da = load_dataset('CESM-LE')
-    # add member coordinate
-    da['member'] = np.arange(1, 1 + da.member.size)
-    da = da - da.mean('time')
-    return da
-
-
-@pytest.fixture
-def uninitialized_da():
-    da = load_dataset('CESM-LE')['SST']
-    # add member coordinate
-    da['member'] = np.arange(1, 1 + da.member.size)
-    da = da - da.mean('time')
-    return da
-
-
-@pytest.fixture
-def hind_3d():
-    da = load_dataset('CESM-DP-SST-3D')['SST'].isel(
-        nlon=slice(0, 10), nlat=slice(0, 12)
-    )
-    da = da - da.mean('init')
-    return da
-
-
-@pytest.fixture
-def fosi_3d():
-    da = load_dataset('FOSI-SST-3D')['SST'].isel(nlon=slice(0, 10), nlat=slice(0, 12))
-    da = da - da.mean('time')
-    return da
-
-
 @pytest.mark.skip(reason='less not properly implemented')
-def test_compute_hindcast_less_m2o(initialized_da, reconstruction_da):
+def test_compute_hindcast_less_m2o(hind_da_initialized_1d, reconstruction_da_1d):
     """Test LESS m2o runs through."""
     actual = (
         compute_hindcast(
-            initialized_da, reconstruction_da, metric='less', comparison='m2o'
+            hind_da_initialized_1d,
+            reconstruction_da_1d,
+            metric='less',
+            comparison='m2o',
         )
         .isnull()
         .any()
@@ -120,13 +35,18 @@ def test_compute_hindcast_less_m2o(initialized_da, reconstruction_da):
 
 @pytest.mark.parametrize('metric', DETERMINISTIC_HINDCAST_METRICS)
 @pytest.mark.parametrize('comparison', HINDCAST_COMPARISONS)
-def test_compute_hindcast(initialized_ds, reconstruction_ds, metric, comparison):
+def test_compute_hindcast(
+    hind_ds_initialized_1d, reconstruction_ds_1d, metric, comparison
+):
     """
     Checks that compute hindcast works without breaking.
     """
     res = (
         compute_hindcast(
-            initialized_ds, reconstruction_ds, metric=metric, comparison=comparison
+            hind_ds_initialized_1d,
+            reconstruction_ds_1d,
+            metric=metric,
+            comparison=comparison,
         )
         .isnull()
         .any()
@@ -136,28 +56,31 @@ def test_compute_hindcast(initialized_ds, reconstruction_ds, metric, comparison)
 
 
 def test_compute_hindcast_lead0_lead1(
-    initialized_ds, initialized_ds_lead0, reconstruction_ds
+    hind_ds_initialized_1d, hind_ds_initialized_1d_lead0, reconstruction_ds_1d
 ):
     """
     Checks that compute hindcast returns the same results with a lead-0 and lead-1
     framework.
     """
     res1 = compute_hindcast(
-        initialized_ds, reconstruction_ds, metric='rmse', comparison='e2o'
+        hind_ds_initialized_1d, reconstruction_ds_1d, metric='rmse', comparison='e2o',
     )
     res2 = compute_hindcast(
-        initialized_ds_lead0, reconstruction_ds, metric='rmse', comparison='e2o'
+        hind_ds_initialized_1d_lead0,
+        reconstruction_ds_1d,
+        metric='rmse',
+        comparison='e2o',
     )
     assert (res1.SST.values == res2.SST.values).all()
 
 
 @pytest.mark.parametrize('metric', DETERMINISTIC_HINDCAST_METRICS)
-def test_persistence(initialized_da, reconstruction_da, metric):
+def test_persistence(hind_da_initialized_1d, reconstruction_da_1d, metric):
     """
     Checks that compute persistence works without breaking.
     """
     res = (
-        compute_persistence(initialized_da, reconstruction_da, metric=metric)
+        compute_persistence(hind_da_initialized_1d, reconstruction_da_1d, metric=metric)
         .isnull()
         .any()
     )
@@ -165,24 +88,31 @@ def test_persistence(initialized_da, reconstruction_da, metric):
 
 
 def test_persistence_lead0_lead1(
-    initialized_ds, initialized_ds_lead0, reconstruction_ds
+    hind_ds_initialized_1d, hind_ds_initialized_1d_lead0, reconstruction_ds_1d
 ):
     """
     Checks that compute persistence returns the same results with a lead-0 and lead-1
     framework.
     """
-    res1 = compute_persistence(initialized_ds, reconstruction_ds, metric='rmse')
-    res2 = compute_persistence(initialized_ds_lead0, reconstruction_ds, metric='rmse')
+    res1 = compute_persistence(
+        hind_ds_initialized_1d, reconstruction_ds_1d, metric='rmse'
+    )
+    res2 = compute_persistence(
+        hind_ds_initialized_1d_lead0, reconstruction_ds_1d, metric='rmse'
+    )
     assert (res1.SST.values == res2.SST.values).all()
 
 
-def test_uninitialized(uninitialized_da, reconstruction_da):
+def test_uninitialized(hind_da_uninitialized_1d, reconstruction_da_1d):
     """
     Checks that compute uninitialized works without breaking.
     """
     res = (
         compute_uninitialized(
-            uninitialized_da, reconstruction_da, metric='rmse', comparison='e2o'
+            hind_da_uninitialized_1d,
+            reconstruction_da_1d,
+            metric='rmse',
+            comparison='e2o',
         )
         .isnull()
         .any()
@@ -191,15 +121,15 @@ def test_uninitialized(uninitialized_da, reconstruction_da):
 
 
 def test_bootstrap_hindcast_da1d_not_nan(
-    initialized_da, uninitialized_da, reconstruction_da
+    hind_da_initialized_1d, hind_da_uninitialized_1d, reconstruction_da_1d
 ):
     """
     Checks that there are no NaNs on bootstrap hindcast of 1D da.
     """
     actual = bootstrap_hindcast(
-        initialized_da,
-        uninitialized_da,
-        reconstruction_da,
+        hind_da_initialized_1d,
+        hind_da_uninitialized_1d,
+        reconstruction_da_1d,
         metric='rmse',
         comparison='e2o',
         sig=50,
@@ -212,41 +142,51 @@ def test_bootstrap_hindcast_da1d_not_nan(
 
 
 @pytest.mark.parametrize('metric', ('AnomCorr', 'test', 'None'))
-def test_compute_hindcast_metric_keyerrors(initialized_ds, reconstruction_ds, metric):
+def test_compute_hindcast_metric_keyerrors(
+    hind_ds_initialized_1d, reconstruction_ds_1d, metric
+):
     """
     Checks that wrong metric names get caught.
     """
     with pytest.raises(KeyError) as excinfo:
         compute_hindcast(
-            initialized_ds, reconstruction_ds, comparison='e2o', metric=metric
+            hind_ds_initialized_1d,
+            reconstruction_ds_1d,
+            comparison='e2o',
+            metric=metric,
         )
     assert 'Specify metric from' in str(excinfo.value)
 
 
 @pytest.mark.parametrize('comparison', ('ensemblemean', 'test', 'None'))
 def test_compute_hindcast_comparison_keyerrors(
-    initialized_ds, reconstruction_ds, comparison
+    hind_ds_initialized_1d, reconstruction_ds_1d, comparison
 ):
     """
     Checks that wrong comparison names get caught.
     """
     with pytest.raises(KeyError) as excinfo:
         compute_hindcast(
-            initialized_ds, reconstruction_ds, comparison=comparison, metric='mse'
+            hind_ds_initialized_1d,
+            reconstruction_ds_1d,
+            comparison=comparison,
+            metric='mse',
         )
     assert 'Specify comparison from' in str(excinfo.value)
 
 
 @pytest.mark.parametrize('metric', ('rmse', 'pearson_r'))
-def test_compute_hindcast_dask_spatial(hind_3d, fosi_3d, metric):
+def test_compute_hindcast_dask_spatial(
+    hind_da_initialized_3d, reconstruction_da_3d, metric
+):
     """Chunking along spatial dims."""
     # chunk over dims in both
-    for dim in hind_3d.dims:
-        if dim in fosi_3d.dims:
+    for dim in hind_da_initialized_3d.dims:
+        if dim in reconstruction_da_3d.dims:
             step = 5
             res_chunked = compute_hindcast(
-                hind_3d.chunk({dim: step}),
-                fosi_3d.chunk({dim: step}),
+                hind_da_initialized_3d.chunk({dim: step}),
+                reconstruction_da_3d.chunk({dim: step}),
                 comparison='e2o',
                 metric=metric,
             )
@@ -257,40 +197,47 @@ def test_compute_hindcast_dask_spatial(hind_3d, fosi_3d, metric):
 
 @pytest.mark.skip(reason='not yet implemented')
 @pytest.mark.parametrize('metric', ('rmse', 'pearson_r'))
-def test_compute_hindcast_dask_climpred_dims(hind_3d, fosi_3d, metric):
+def test_compute_hindcast_dask_climpred_dims(
+    hind_da_initialized_3d, reconstruction_da_3d, metric
+):
     """Chunking along climpred dims if available."""
     step = 5
     for dim in CLIMPRED_DIMS:
-        if dim in hind_3d.dims:
-            hind_3d = hind_3d.chunk({dim: step})
-        if dim in fosi_3d.dims:
-            fosi_3d = fosi_3d.chunk({dim: step})
+        if dim in hind_da_initialized_3d.dims:
+            hind_da_initialized_3d = hind_da_initialized_3d.chunk({dim: step})
+        if dim in reconstruction_da_3d.dims:
+            reconstruction_da_3d = reconstruction_da_3d.chunk({dim: step})
         res_chunked = compute_hindcast(
-            hind_3d, fosi_3d, comparison='e2o', metric=metric
+            hind_da_initialized_3d,
+            reconstruction_da_3d,
+            comparison='e2o',
+            metric=metric,
         )
         # check for chunks
         assert dask.is_dask_collection(res_chunked)
         assert res_chunked.chunks is not None
 
 
-def test_compute_hindcast_CESM_3D_keep_coords(hind_3d, fosi_3d):
+def test_compute_hindcast_CESM_3D_keep_coords(
+    hind_da_initialized_3d, reconstruction_da_3d
+):
     """Test that no coords are lost in compute_hindcast with the CESM sample data."""
-    s = compute_hindcast(hind_3d, fosi_3d)
-    for c in hind_3d.drop('init').coords:
+    s = compute_hindcast(hind_da_initialized_3d, reconstruction_da_3d)
+    for c in hind_da_initialized_3d.drop('init').coords:
         assert c in s.coords
 
 
 def test_bootstrap_hindcast_keeps_lead_units(
-    initialized_da, uninitialized_da, observations_da
+    hind_da_initialized_1d, hind_da_uninitialized_1d, observations_da_1d
 ):
     """Test that lead units is kept in compute."""
     sig = 95
     units = 'years'
-    initialized_da['lead'].attrs['units'] = units
+    hind_da_initialized_1d['lead'].attrs['units'] = units
     actual = bootstrap_hindcast(
-        initialized_da,
-        uninitialized_da,
-        observations_da,
+        hind_da_initialized_1d,
+        hind_da_uninitialized_1d,
+        observations_da_1d,
         metric='mse',
         bootstrap=2,
         comparison='e2o',

--- a/climpred/tests/test_hindcast_prediction.py
+++ b/climpred/tests/test_hindcast_prediction.py
@@ -19,7 +19,7 @@ DETERMINISTIC_HINDCAST_METRICS.remove('uacc')
 
 @pytest.mark.skip(reason='less not properly implemented')
 def test_compute_hindcast_less_m2o(hind_da_initialized_1d, reconstruction_da_1d):
-    """Test LESS m2o runs through."""
+    """Test LESS m2o runs through"""
     actual = (
         compute_hindcast(
             hind_da_initialized_1d,

--- a/climpred/tests/test_perfectModelEnsemble_class.py
+++ b/climpred/tests/test_perfectModelEnsemble_class.py
@@ -14,48 +14,38 @@ def test_perfectModelEnsemble_init_da(PM_da_initialized_1d):
     assert pm
 
 
-def test_add_control(PM_ds_initialized_1d, PM_ds_control_1d):
+def test_add_control(perfectModelEnsemble_initialized_control):
     """Test to see if control can be added to PerfectModelEnsemble"""
-    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
-    pm = pm.add_control(PM_ds_control_1d)
-    assert pm.get_control()
+    assert perfectModelEnsemble_initialized_control.get_control()
 
 
-def test_generate_uninit(PM_ds_initialized_1d, PM_ds_control_1d):
+def test_generate_uninit(perfectModelEnsemble_initialized_control):
     """Test to see if uninitialized ensemble can be bootstrapped"""
-    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
-    pm = pm.add_control(PM_ds_control_1d)
+    pm = perfectModelEnsemble_initialized_control
     pm = pm.generate_uninitialized()
     assert pm.get_uninitialized()
 
 
-def test_compute_metric(PM_ds_initialized_1d, PM_ds_control_1d):
+def test_compute_metric(perfectModelEnsemble_initialized_control):
     """Test that metric can be computed for perfect model ensemble"""
-    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
-    pm = pm.add_control(PM_ds_control_1d)
-    pm.compute_metric()
+    perfectModelEnsemble_initialized_control.compute_metric()
 
 
-def test_compute_uninitialized(PM_ds_initialized_1d, PM_ds_control_1d):
+def test_compute_uninitialized(perfectModelEnsemble_initialized_control):
     """Test that compute uninitialized can be run for perfect model ensemble"""
-    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
-    pm = pm.add_control(PM_ds_control_1d)
+    pm = perfectModelEnsemble_initialized_control
     pm = pm.generate_uninitialized()
     pm.compute_uninitialized()
 
 
-def test_compute_persistence(PM_ds_initialized_1d, PM_ds_control_1d):
+def test_compute_persistence(perfectModelEnsemble_initialized_control):
     """Test that compute persistence can be run for perfect model ensemble"""
-    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
-    pm = pm.add_control(PM_ds_control_1d)
-    pm.compute_persistence()
+    perfectModelEnsemble_initialized_control.compute_persistence()
 
 
-def test_bootstrap(PM_ds_initialized_1d, PM_ds_control_1d):
+def test_bootstrap(perfectModelEnsemble_initialized_control):
     """Test that perfect model ensemble object can be bootstrapped"""
-    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
-    pm = pm.add_control(PM_ds_control_1d)
-    pm.bootstrap(bootstrap=2)
+    perfectModelEnsemble_initialized_control.bootstrap(bootstrap=2)
 
 
 def test_get_initialized(PM_ds_initialized_1d):
@@ -65,21 +55,18 @@ def test_get_initialized(PM_ds_initialized_1d):
     assert init == pm._datasets['initialized']
 
 
-def test_get_uninitialized(PM_ds_initialized_1d, PM_ds_control_1d):
+def test_get_uninitialized(perfectModelEnsemble_initialized_control):
     """Test whether get_uninitialized function works."""
-    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
-    pm = pm.add_control(PM_ds_control_1d)
+    pm = perfectModelEnsemble_initialized_control
     pm = pm.generate_uninitialized()
     uninit = pm.get_uninitialized()
     assert uninit == pm._datasets['uninitialized']
 
 
-def test_get_control(PM_ds_initialized_1d, PM_ds_control_1d):
+def test_get_control(perfectModelEnsemble_initialized_control):
     """Test whether get_control function works."""
-    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
-    pm = pm.add_control(PM_ds_control_1d)
-    ctrl = pm.get_control()
-    assert ctrl == pm._datasets['control']
+    ctrl = perfectModelEnsemble_initialized_control.get_control()
+    assert ctrl == perfectModelEnsemble_initialized_control._datasets['control']
 
 
 def test_inplace(PM_ds_initialized_1d, PM_ds_control_1d):

--- a/climpred/tests/test_perfectModelEnsemble_class.py
+++ b/climpred/tests/test_perfectModelEnsemble_class.py
@@ -1,125 +1,96 @@
-import pytest
-
 from climpred import PerfectModelEnsemble
-from climpred.tutorial import load_dataset
 
 
-@pytest.fixture
-def pm_da_ds1d():
-    da = load_dataset('MPI-PM-DP-1D')
-    da = da['tos'].isel(area=1, period=-1)
-    return da
-
-
-@pytest.fixture
-def pm_da_control1d():
-    da = load_dataset('MPI-control-1D')
-    da = da['tos'].isel(area=1, period=-1)
-    return da
-
-
-@pytest.fixture
-def pm_ds_ds1d():
-    ds = load_dataset('MPI-PM-DP-1D').isel(area=1, period=-1)
-    return ds
-
-
-@pytest.fixture
-def pm_ds_control1d():
-    ds = load_dataset('MPI-control-1D').isel(area=1, period=-1)
-    return ds
-
-
-def test_perfectModelEnsemble_init(pm_ds_ds1d):
+def test_perfectModelEnsemble_init(PM_ds_initialized_1d):
     """Test to see if perfect model ensemble can be initialized"""
-    pm = PerfectModelEnsemble(pm_ds_ds1d)
+    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
     print(PerfectModelEnsemble)
     assert pm
 
 
-def test_perfectModelEnsemble_init_da(pm_da_ds1d):
+def test_perfectModelEnsemble_init_da(PM_da_initialized_1d):
     """Test to see if perfect model ensemble can be initialized with da"""
-    pm = PerfectModelEnsemble(pm_da_ds1d)
+    pm = PerfectModelEnsemble(PM_da_initialized_1d)
     assert pm
 
 
-def test_add_control(pm_ds_ds1d, pm_ds_control1d):
+def test_add_control(PM_ds_initialized_1d, PM_ds_control_1d):
     """Test to see if control can be added to PerfectModelEnsemble"""
-    pm = PerfectModelEnsemble(pm_ds_ds1d)
-    pm = pm.add_control(pm_ds_control1d)
+    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
+    pm = pm.add_control(PM_ds_control_1d)
     assert pm.get_control()
 
 
-def test_generate_uninit(pm_ds_ds1d, pm_ds_control1d):
+def test_generate_uninit(PM_ds_initialized_1d, PM_ds_control_1d):
     """Test to see if uninitialized ensemble can be bootstrapped"""
-    pm = PerfectModelEnsemble(pm_ds_ds1d)
-    pm = pm.add_control(pm_ds_control1d)
+    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
+    pm = pm.add_control(PM_ds_control_1d)
     pm = pm.generate_uninitialized()
     assert pm.get_uninitialized()
 
 
-def test_compute_metric(pm_ds_ds1d, pm_ds_control1d):
+def test_compute_metric(PM_ds_initialized_1d, PM_ds_control_1d):
     """Test that metric can be computed for perfect model ensemble"""
-    pm = PerfectModelEnsemble(pm_ds_ds1d)
-    pm = pm.add_control(pm_ds_control1d)
+    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
+    pm = pm.add_control(PM_ds_control_1d)
     pm.compute_metric()
 
 
-def test_compute_uninitialized(pm_ds_ds1d, pm_ds_control1d):
+def test_compute_uninitialized(PM_ds_initialized_1d, PM_ds_control_1d):
     """Test that compute uninitialized can be run for perfect model ensemble"""
-    pm = PerfectModelEnsemble(pm_ds_ds1d)
-    pm = pm.add_control(pm_ds_control1d)
+    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
+    pm = pm.add_control(PM_ds_control_1d)
     pm = pm.generate_uninitialized()
     pm.compute_uninitialized()
 
 
-def test_compute_persistence(pm_ds_ds1d, pm_ds_control1d):
+def test_compute_persistence(PM_ds_initialized_1d, PM_ds_control_1d):
     """Test that compute persistence can be run for perfect model ensemble"""
-    pm = PerfectModelEnsemble(pm_ds_ds1d)
-    pm = pm.add_control(pm_ds_control1d)
+    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
+    pm = pm.add_control(PM_ds_control_1d)
     pm.compute_persistence()
 
 
-def test_bootstrap(pm_ds_ds1d, pm_ds_control1d):
+def test_bootstrap(PM_ds_initialized_1d, PM_ds_control_1d):
     """Test that perfect model ensemble object can be bootstrapped"""
-    pm = PerfectModelEnsemble(pm_ds_ds1d)
-    pm = pm.add_control(pm_ds_control1d)
+    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
+    pm = pm.add_control(PM_ds_control_1d)
     pm.bootstrap(bootstrap=2)
 
 
-def test_get_initialized(pm_ds_ds1d):
+def test_get_initialized(PM_ds_initialized_1d):
     """Test whether get_initialized function works."""
-    pm = PerfectModelEnsemble(pm_ds_ds1d)
+    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
     init = pm.get_initialized()
     assert init == pm._datasets['initialized']
 
 
-def test_get_uninitialized(pm_ds_ds1d, pm_ds_control1d):
+def test_get_uninitialized(PM_ds_initialized_1d, PM_ds_control_1d):
     """Test whether get_uninitialized function works."""
-    pm = PerfectModelEnsemble(pm_ds_ds1d)
-    pm = pm.add_control(pm_ds_control1d)
+    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
+    pm = pm.add_control(PM_ds_control_1d)
     pm = pm.generate_uninitialized()
     uninit = pm.get_uninitialized()
     assert uninit == pm._datasets['uninitialized']
 
 
-def test_get_control(pm_ds_ds1d, pm_ds_control1d):
+def test_get_control(PM_ds_initialized_1d, PM_ds_control_1d):
     """Test whether get_control function works."""
-    pm = PerfectModelEnsemble(pm_ds_ds1d)
-    pm = pm.add_control(pm_ds_control1d)
+    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
+    pm = pm.add_control(PM_ds_control_1d)
     ctrl = pm.get_control()
     assert ctrl == pm._datasets['control']
 
 
-def test_inplace(pm_ds_ds1d, pm_ds_control1d):
+def test_inplace(PM_ds_initialized_1d, PM_ds_control_1d):
     """Tests that inplace operations do not work."""
-    pm = PerfectModelEnsemble(pm_ds_ds1d)
+    pm = PerfectModelEnsemble(PM_ds_initialized_1d)
     # Adding a control.
-    pm.add_control(pm_ds_control1d)
-    with_ctrl = pm.add_control(pm_ds_control1d)
+    pm.add_control(PM_ds_control_1d)
+    with_ctrl = pm.add_control(PM_ds_control_1d)
     assert pm != with_ctrl
     # Adding an uninitialized ensemble.
-    pm = pm.add_control(pm_ds_control1d)
+    pm = pm.add_control(PM_ds_control_1d)
     pm.generate_uninitialized()
     with_uninit = pm.generate_uninitialized()
     assert pm != with_uninit

--- a/climpred/tests/test_perfectModelEnsemble_class.py
+++ b/climpred/tests/test_perfectModelEnsemble_class.py
@@ -1,62 +1,55 @@
+import pytest
+
 from climpred import PerfectModelEnsemble
 
 
 def test_perfectModelEnsemble_init(PM_ds_initialized_1d):
-    """Test to see if perfect model ensemble can be initialized"""
+    """Test to see if perfect model ensemble can be initialized."""
     pm = PerfectModelEnsemble(PM_ds_initialized_1d)
-    print(PerfectModelEnsemble)
     assert pm
 
 
 def test_perfectModelEnsemble_init_da(PM_da_initialized_1d):
-    """Test to see if perfect model ensemble can be initialized with da"""
+    """Test to see if perfect model ensemble can be initialized with da."""
     pm = PerfectModelEnsemble(PM_da_initialized_1d)
     assert pm
 
 
-def test_add_control(perfectModelEnsemble_initialized_control):
-    """Test to see if control can be added to PerfectModelEnsemble"""
-    assert perfectModelEnsemble_initialized_control.get_control()
+@pytest.mark.parametrize(
+    'handle', ['get_uninitialized', 'get_control', 'get_initialized'],
+)
+def test_perfectModelEnsemble_initialized_control_handles_returns(
+    perfectModelEnsemble_initialized_control, handle
+):
+    """Test that perfect model ensemble object gets a return from `handle`."""
+    assert getattr(perfectModelEnsemble_initialized_control, handle)
 
 
-def test_generate_uninit(perfectModelEnsemble_initialized_control):
-    """Test to see if uninitialized ensemble can be bootstrapped"""
-    pm = perfectModelEnsemble_initialized_control
-    pm = pm.generate_uninitialized()
-    assert pm.get_uninitialized()
-
-
-def test_compute_metric(perfectModelEnsemble_initialized_control):
-    """Test that metric can be computed for perfect model ensemble"""
-    perfectModelEnsemble_initialized_control.compute_metric()
-
-
-def test_compute_uninitialized(perfectModelEnsemble_initialized_control):
-    """Test that compute uninitialized can be run for perfect model ensemble"""
-    pm = perfectModelEnsemble_initialized_control
-    pm = pm.generate_uninitialized()
-    pm.compute_uninitialized()
-
-
-def test_compute_persistence(perfectModelEnsemble_initialized_control):
-    """Test that compute persistence can be run for perfect model ensemble"""
-    perfectModelEnsemble_initialized_control.compute_persistence()
-
-
-def test_bootstrap(perfectModelEnsemble_initialized_control):
-    """Test that perfect model ensemble object can be bootstrapped"""
-    perfectModelEnsemble_initialized_control.bootstrap(bootstrap=2)
+@pytest.mark.parametrize(
+    'handle',
+    [
+        'compute_persistence',
+        'compute_uninitialized',
+        'bootstrap(bootstrap=2)',
+        'compute_metric',
+    ],
+)
+def test_perfectModelEnsemble_initialized_control_handles(
+    perfectModelEnsemble_initialized_control, handle
+):
+    """Test that perfect model ensemble object can use `handle`."""
+    getattr(perfectModelEnsemble_initialized_control, handle)
 
 
 def test_get_initialized(PM_ds_initialized_1d):
-    """Test whether get_initialized function works."""
+    """Test whether get_initialized function works.."""
     pm = PerfectModelEnsemble(PM_ds_initialized_1d)
     init = pm.get_initialized()
     assert init == pm._datasets['initialized']
 
 
 def test_get_uninitialized(perfectModelEnsemble_initialized_control):
-    """Test whether get_uninitialized function works."""
+    """Test whether get_uninitialized function works.."""
     pm = perfectModelEnsemble_initialized_control
     pm = pm.generate_uninitialized()
     uninit = pm.get_uninitialized()
@@ -64,13 +57,13 @@ def test_get_uninitialized(perfectModelEnsemble_initialized_control):
 
 
 def test_get_control(perfectModelEnsemble_initialized_control):
-    """Test whether get_control function works."""
+    """Test whether get_control function works.."""
     ctrl = perfectModelEnsemble_initialized_control.get_control()
     assert ctrl == perfectModelEnsemble_initialized_control._datasets['control']
 
 
 def test_inplace(PM_ds_initialized_1d, PM_ds_control_1d):
-    """Tests that inplace operations do not work."""
+    """Tests that inplace operations do not work.."""
     pm = PerfectModelEnsemble(PM_ds_initialized_1d)
     # Adding a control.
     pm.add_control(PM_ds_control_1d)

--- a/climpred/tests/test_perfectModelEnsemble_class.py
+++ b/climpred/tests/test_perfectModelEnsemble_class.py
@@ -1,55 +1,62 @@
-import pytest
-
 from climpred import PerfectModelEnsemble
 
 
 def test_perfectModelEnsemble_init(PM_ds_initialized_1d):
-    """Test to see if perfect model ensemble can be initialized."""
+    """Test to see if perfect model ensemble can be initialized"""
     pm = PerfectModelEnsemble(PM_ds_initialized_1d)
+    print(PerfectModelEnsemble)
     assert pm
 
 
 def test_perfectModelEnsemble_init_da(PM_da_initialized_1d):
-    """Test to see if perfect model ensemble can be initialized with da."""
+    """Test to see if perfect model ensemble can be initialized with da"""
     pm = PerfectModelEnsemble(PM_da_initialized_1d)
     assert pm
 
 
-@pytest.mark.parametrize(
-    'handle', ['get_uninitialized', 'get_control', 'get_initialized'],
-)
-def test_perfectModelEnsemble_initialized_control_handles_returns(
-    perfectModelEnsemble_initialized_control, handle
-):
-    """Test that perfect model ensemble object gets a return from `handle`."""
-    assert getattr(perfectModelEnsemble_initialized_control, handle)
+def test_add_control(perfectModelEnsemble_initialized_control):
+    """Test to see if control can be added to PerfectModelEnsemble"""
+    assert perfectModelEnsemble_initialized_control.get_control()
 
 
-@pytest.mark.parametrize(
-    'handle',
-    [
-        'compute_persistence',
-        'compute_uninitialized',
-        'bootstrap(bootstrap=2)',
-        'compute_metric',
-    ],
-)
-def test_perfectModelEnsemble_initialized_control_handles(
-    perfectModelEnsemble_initialized_control, handle
-):
-    """Test that perfect model ensemble object can use `handle`."""
-    getattr(perfectModelEnsemble_initialized_control, handle)
+def test_generate_uninit(perfectModelEnsemble_initialized_control):
+    """Test to see if uninitialized ensemble can be bootstrapped"""
+    pm = perfectModelEnsemble_initialized_control
+    pm = pm.generate_uninitialized()
+    assert pm.get_uninitialized()
+
+
+def test_compute_metric(perfectModelEnsemble_initialized_control):
+    """Test that metric can be computed for perfect model ensemble"""
+    perfectModelEnsemble_initialized_control.compute_metric()
+
+
+def test_compute_uninitialized(perfectModelEnsemble_initialized_control):
+    """Test that compute uninitialized can be run for perfect model ensemble"""
+    pm = perfectModelEnsemble_initialized_control
+    pm = pm.generate_uninitialized()
+    pm.compute_uninitialized()
+
+
+def test_compute_persistence(perfectModelEnsemble_initialized_control):
+    """Test that compute persistence can be run for perfect model ensemble"""
+    perfectModelEnsemble_initialized_control.compute_persistence()
+
+
+def test_bootstrap(perfectModelEnsemble_initialized_control):
+    """Test that perfect model ensemble object can be bootstrapped"""
+    perfectModelEnsemble_initialized_control.bootstrap(bootstrap=2)
 
 
 def test_get_initialized(PM_ds_initialized_1d):
-    """Test whether get_initialized function works.."""
+    """Test whether get_initialized function works."""
     pm = PerfectModelEnsemble(PM_ds_initialized_1d)
     init = pm.get_initialized()
     assert init == pm._datasets['initialized']
 
 
 def test_get_uninitialized(perfectModelEnsemble_initialized_control):
-    """Test whether get_uninitialized function works.."""
+    """Test whether get_uninitialized function works."""
     pm = perfectModelEnsemble_initialized_control
     pm = pm.generate_uninitialized()
     uninit = pm.get_uninitialized()
@@ -57,13 +64,13 @@ def test_get_uninitialized(perfectModelEnsemble_initialized_control):
 
 
 def test_get_control(perfectModelEnsemble_initialized_control):
-    """Test whether get_control function works.."""
+    """Test whether get_control function works."""
     ctrl = perfectModelEnsemble_initialized_control.get_control()
     assert ctrl == perfectModelEnsemble_initialized_control._datasets['control']
 
 
 def test_inplace(PM_ds_initialized_1d, PM_ds_control_1d):
-    """Tests that inplace operations do not work.."""
+    """Tests that inplace operations do not work."""
     pm = PerfectModelEnsemble(PM_ds_initialized_1d)
     # Adding a control.
     pm.add_control(PM_ds_control_1d)

--- a/climpred/tests/test_perfect_model_prediction.py
+++ b/climpred/tests/test_perfect_model_prediction.py
@@ -4,7 +4,6 @@ import pytest
 from climpred.bootstrap import bootstrap_perfect_model
 from climpred.constants import CLIMPRED_DIMS, DETERMINISTIC_PM_METRICS
 from climpred.prediction import compute_perfect_model, compute_persistence
-from climpred.tutorial import load_dataset
 
 # uacc is sqrt(MSSS), fails when MSSS negative
 DETERMINISTIC_PM_METRICS_LUACC = DETERMINISTIC_PM_METRICS.copy()
@@ -13,67 +12,19 @@ DETERMINISTIC_PM_METRICS_LUACC.remove('uacc')
 # run less tests
 PM_COMPARISONS = {'m2c': '', 'e2c': ''}
 
-
-@pytest.fixture
-def pm_da_ds1d():
-    da = load_dataset('MPI-PM-DP-1D')
-    da = da['tos'].isel(area=1, period=-1)
-    return da
-
-
-@pytest.fixture
-def pm_da_ds1d_lead0():
-    da = load_dataset('MPI-PM-DP-1D')
-    da = da['tos'].isel(area=1, period=-1)
-    # Convert to lead zero for testing
-    da['lead'] -= 1
-    da['init'] += 1
-    return da
-
-
-@pytest.fixture
-def pm_da_control1d():
-    da = load_dataset('MPI-control-1D')
-    da = da['tos'].isel(area=1, period=-1)
-    return da
-
-
-@pytest.fixture
-def pm_ds_ds1d():
-    ds = load_dataset('MPI-PM-DP-1D').isel(area=1, period=-1)
-    return ds
-
-
-@pytest.fixture
-def pm_ds_control1d():
-    ds = load_dataset('MPI-control-1D').isel(area=1, period=-1)
-    return ds
-
-
-@pytest.fixture
-def ds_3d_NA():
-    """ds North Atlantic"""
-    ds = load_dataset('MPI-PM-DP-3D')['tos'].sel(x=slice(120, 130), y=slice(50, 60))
-    return ds
-
-
-@pytest.fixture
-def control_3d_NA():
-    """control North Atlantic"""
-    ds = load_dataset('MPI-control-3D')['tos'].sel(x=slice(120, 130), y=slice(50, 60))
-    return ds
+BOOTSTRAP = 3
 
 
 @pytest.mark.parametrize('metric', ('rmse', 'pearson_r'))
-def test_pvalue_from_bootstrapping(pm_da_ds1d, pm_da_control1d, metric):
+def test_pvalue_from_bootstrapping(PM_da_initialized_1d, PM_da_control_1d, metric):
     """Test that pvalue of initialized ensemble first lead is close to 0."""
     sig = 95
     actual = (
         bootstrap_perfect_model(
-            pm_da_ds1d,
-            pm_da_control1d,
+            PM_da_initialized_1d,
+            PM_da_control_1d,
             metric=metric,
-            bootstrap=5,
+            bootstrap=BOOTSTRAP,
             comparison='e2c',
             sig=sig,
             dim='init',
@@ -85,12 +36,16 @@ def test_pvalue_from_bootstrapping(pm_da_ds1d, pm_da_control1d, metric):
 
 
 @pytest.mark.parametrize('metric', DETERMINISTIC_PM_METRICS_LUACC)
-def test_compute_persistence_ds1d_not_nan(pm_ds_ds1d, pm_ds_control1d, metric):
+def test_compute_persistence_ds1d_not_nan(
+    PM_ds_initialized_1d, PM_ds_control_1d, metric
+):
     """
     Checks that there are no NaNs on persistence forecast of 1D time series.
     """
     actual = (
-        compute_persistence(pm_ds_ds1d, pm_ds_control1d, metric=metric).isnull().any()
+        compute_persistence(PM_ds_initialized_1d, PM_ds_control_1d, metric=metric)
+        .isnull()
+        .any()
     )
     for var in actual.data_vars:
         assert not actual[var]
@@ -98,27 +53,32 @@ def test_compute_persistence_ds1d_not_nan(pm_ds_ds1d, pm_ds_control1d, metric):
 
 @pytest.mark.parametrize('metric', DETERMINISTIC_PM_METRICS_LUACC)
 def test_compute_persistence_lead0_lead1(
-    pm_da_ds1d, pm_da_ds1d_lead0, pm_da_control1d, metric
+    PM_da_initialized_1d, PM_da_initialized_1d_lead0, PM_da_control_1d, metric
 ):
     """
     Checks that persistence forecast results are identical for a lead 0 and lead 1 setup
     """
-    res1 = compute_persistence(pm_da_ds1d, pm_da_control1d, metric=metric)
-    res2 = compute_persistence(pm_da_ds1d_lead0, pm_da_control1d, metric=metric)
+    res1 = compute_persistence(PM_da_initialized_1d, PM_da_control_1d, metric=metric)
+    res2 = compute_persistence(
+        PM_da_initialized_1d_lead0, PM_da_control_1d, metric=metric
+    )
     assert (res1.values == res2.values).all()
 
 
 @pytest.mark.parametrize('comparison', PM_COMPARISONS)
 @pytest.mark.parametrize('metric', DETERMINISTIC_PM_METRICS_LUACC)
 def test_compute_perfect_model_da1d_not_nan(
-    pm_da_ds1d, pm_da_control1d, comparison, metric
+    PM_da_initialized_1d, PM_da_control_1d, comparison, metric
 ):
     """
     Checks that there are no NaNs on perfect model metrics of 1D time series.
     """
     actual = (
         compute_perfect_model(
-            pm_da_ds1d, pm_da_control1d, comparison=comparison, metric=metric
+            PM_da_initialized_1d,
+            PM_da_control_1d,
+            comparison=comparison,
+            metric=metric,
         )
         .isnull()
         .any()
@@ -129,31 +89,38 @@ def test_compute_perfect_model_da1d_not_nan(
 @pytest.mark.parametrize('comparison', PM_COMPARISONS)
 @pytest.mark.parametrize('metric', DETERMINISTIC_PM_METRICS_LUACC)
 def test_compute_perfect_model_lead0_lead1(
-    pm_da_ds1d, pm_da_ds1d_lead0, pm_da_control1d, comparison, metric
+    PM_da_initialized_1d,
+    PM_da_initialized_1d_lead0,
+    PM_da_control_1d,
+    comparison,
+    metric,
 ):
     """
     Checks that metric results are identical for a lead 0 and lead 1 setup.
     """
     res1 = compute_perfect_model(
-        pm_da_ds1d, pm_da_control1d, comparison=comparison, metric=metric
+        PM_da_initialized_1d, PM_da_control_1d, comparison=comparison, metric=metric,
     )
     res2 = compute_perfect_model(
-        pm_da_ds1d_lead0, pm_da_control1d, comparison=comparison, metric=metric
+        PM_da_initialized_1d_lead0,
+        PM_da_control_1d,
+        comparison=comparison,
+        metric=metric,
     )
     assert (res1.values == res2.values).all()
 
 
-def test_bootstrap_perfect_model_da1d_not_nan(pm_da_ds1d, pm_da_control1d):
+def test_bootstrap_perfect_model_da1d_not_nan(PM_da_initialized_1d, PM_da_control_1d):
     """
     Checks that there are no NaNs on bootstrap perfect_model of 1D da.
     """
     actual = bootstrap_perfect_model(
-        pm_da_ds1d,
-        pm_da_control1d,
+        PM_da_initialized_1d,
+        PM_da_control_1d,
         metric='rmse',
         comparison='e2c',
         sig=50,
-        bootstrap=2,
+        bootstrap=BOOTSTRAP,
     )
     actual_init_skill = actual.sel(kind='init', results='skill').isnull().any()
     assert not actual_init_skill
@@ -161,17 +128,17 @@ def test_bootstrap_perfect_model_da1d_not_nan(pm_da_ds1d, pm_da_control1d):
     assert not actual_uninit_p
 
 
-def test_bootstrap_perfect_model_ds1d_not_nan(pm_ds_ds1d, pm_ds_control1d):
+def test_bootstrap_perfect_model_ds1d_not_nan(PM_ds_initialized_1d, PM_ds_control_1d):
     """
     Checks that there are no NaNs on bootstrap perfect_model of 1D ds.
     """
     actual = bootstrap_perfect_model(
-        pm_ds_ds1d,
-        pm_ds_control1d,
+        PM_ds_initialized_1d,
+        PM_ds_control_1d,
         metric='rmse',
         comparison='e2c',
         sig=50,
-        bootstrap=2,
+        bootstrap=BOOTSTRAP,
     )
     for var in actual.data_vars:
         actual_init_skill = actual[var].sel(kind='init', results='skill').isnull().any()
@@ -182,42 +149,46 @@ def test_bootstrap_perfect_model_ds1d_not_nan(pm_ds_ds1d, pm_ds_control1d):
 
 
 @pytest.mark.parametrize('metric', ('AnomCorr', 'test', 'None'))
-def test_compute_perfect_model_metric_keyerrors(pm_da_ds1d, pm_da_control1d, metric):
+def test_compute_perfect_model_metric_keyerrors(
+    PM_da_initialized_1d, PM_da_control_1d, metric
+):
     """
     Checks that wrong metric names get caught.
     """
     with pytest.raises(KeyError) as excinfo:
         compute_perfect_model(
-            pm_da_ds1d, pm_da_control1d, comparison='e2c', metric=metric
+            PM_da_initialized_1d, PM_da_control_1d, comparison='e2c', metric=metric,
         )
     assert 'Specify metric from' in str(excinfo.value)
 
 
 @pytest.mark.parametrize('comparison', ('ensemblemean', 'test', 'None'))
 def test_compute_perfect_model_comparison_keyerrors(
-    pm_da_ds1d, pm_da_control1d, comparison
+    PM_da_initialized_1d, PM_da_control_1d, comparison
 ):
     """
     Checks that wrong comparison names get caught.
     """
     with pytest.raises(KeyError) as excinfo:
         compute_perfect_model(
-            pm_da_ds1d, pm_da_control1d, comparison=comparison, metric='mse'
+            PM_da_initialized_1d, PM_da_control_1d, comparison=comparison, metric='mse',
         )
     assert 'Specify comparison from' in str(excinfo.value)
 
 
 @pytest.mark.parametrize('metric', ('rmse', 'pearson_r'))
 @pytest.mark.parametrize('comparison', PM_COMPARISONS)
-def test_compute_pm_dask_spatial(ds_3d_NA, control_3d_NA, comparison, metric):
+def test_compute_pm_dask_spatial(
+    PM_ds_initialized_3d, PM_ds_control_3d, comparison, metric
+):
     """Chunking along spatial dims."""
     # chunk over dims in both
-    for dim in ds_3d_NA.dims:
-        if dim in control_3d_NA.dims:
+    for dim in PM_ds_initialized_3d.dims:
+        if dim in PM_ds_control_3d.dims:
             step = 5
             res_chunked = compute_perfect_model(
-                ds_3d_NA.chunk({dim: step}),
-                control_3d_NA.chunk({dim: step}),
+                PM_ds_initialized_3d.chunk({dim: step}),
+                PM_ds_control_3d.chunk({dim: step}),
                 comparison=comparison,
                 metric=metric,
                 dim='init',
@@ -229,32 +200,40 @@ def test_compute_pm_dask_spatial(ds_3d_NA, control_3d_NA, comparison, metric):
 
 @pytest.mark.parametrize('metric', ('rmse', 'pearson_r'))
 @pytest.mark.parametrize('comparison', PM_COMPARISONS)
-def test_compute_pm_dask_climpred_dims(ds_3d_NA, control_3d_NA, comparison, metric):
+def test_compute_pm_dask_climpred_dims(
+    PM_ds_initialized_3d, PM_ds_control_3d, comparison, metric
+):
     """Chunking along climpred dims if available."""
     step = 5
     for dim in CLIMPRED_DIMS:
-        if dim in ds_3d_NA.dims:
-            ds_3d_NA = ds_3d_NA.chunk({dim: step})
-        if dim in control_3d_NA.dims:
-            control_3d_NA = control_3d_NA.chunk({dim: step})
+        if dim in PM_ds_initialized_3d.dims:
+            PM_ds_initialized_3d = PM_ds_initialized_3d.chunk({dim: step})
+        if dim in PM_ds_control_3d.dims:
+            PM_ds_control_3d = PM_ds_control_3d.chunk({dim: step})
         res_chunked = compute_perfect_model(
-            ds_3d_NA, control_3d_NA, comparison=comparison, metric=metric, dim='init'
+            PM_ds_initialized_3d,
+            PM_ds_control_3d,
+            comparison=comparison,
+            metric=metric,
+            dim='init',
         )
         # check for chunks
         assert dask.is_dask_collection(res_chunked)
         assert res_chunked.chunks is not None
 
 
-def test_bootstrap_perfect_model_keeps_lead_units(pm_da_ds1d, pm_da_control1d):
+def test_bootstrap_perfect_model_keeps_lead_units(
+    PM_da_initialized_1d, PM_da_control_1d
+):
     """Test that lead units is kept in compute."""
     sig = 95
     units = 'years'
-    pm_da_ds1d.lead.attrs['units'] = 'years'
+    PM_da_initialized_1d.lead.attrs['units'] = 'years'
     actual = bootstrap_perfect_model(
-        pm_da_ds1d,
-        pm_da_control1d,
+        PM_da_initialized_1d,
+        PM_da_control_1d,
         metric='mse',
-        bootstrap=2,
+        bootstrap=BOOTSTRAP,
         comparison='e2c',
         sig=sig,
         dim='init',

--- a/climpred/tests/test_probabilistic.py
+++ b/climpred/tests/test_probabilistic.py
@@ -9,50 +9,14 @@ from climpred.constants import (
     PROBABILISTIC_PM_COMPARISONS,
 )
 from climpred.prediction import compute_hindcast, compute_perfect_model
-from climpred.tutorial import load_dataset
 
-
-@pytest.fixture
-def pm_da_ds1d():
-    da = load_dataset('MPI-PM-DP-1D')
-    da = da['tos'].isel(area=1, period=-1)
-    return da
-
-
-@pytest.fixture
-def pm_da_control1d():
-    da = load_dataset('MPI-control-1D')
-    da = da['tos'].isel(area=1, period=-1)
-    return da
-
-
-@pytest.fixture
-def initialized_da():
-    da = load_dataset('CESM-DP-SST')['SST']
-    da = da - da.mean('init')
-    return da
-
-
-@pytest.fixture
-def uninitialized_da():
-    da = load_dataset('CESM-LE')['SST']
-    # add member coordinate
-    da['member'] = range(1, 1 + da.member.size)
-    da = da - da.mean('time')
-    return da
-
-
-@pytest.fixture
-def observations_da():
-    da = load_dataset('ERSST')['SST']
-    da = da - da.mean('time')
-    return da
+BOOTSTRAP = 3
 
 
 @pytest.mark.parametrize('comparison', PROBABILISTIC_PM_COMPARISONS)
 @pytest.mark.parametrize('metric', PROBABILISTIC_METRICS)
 def test_compute_perfect_model_da1d_not_nan_probabilistic(
-    pm_da_ds1d, pm_da_control1d, metric, comparison
+    PM_da_initialized_1d, PM_da_control_1d, metric, comparison
 ):
     """
     Checks that there are no NaNs on perfect model probabilistic metrics of 1D
@@ -72,8 +36,8 @@ def test_compute_perfect_model_da1d_not_nan_probabilistic(
         func = None
 
     actual = compute_perfect_model(
-        pm_da_ds1d,
-        pm_da_control1d,
+        PM_da_initialized_1d,
+        PM_da_control_1d,
         comparison=comparison,
         metric=metric,
         threshold=threshold,
@@ -88,13 +52,13 @@ def test_compute_perfect_model_da1d_not_nan_probabilistic(
 @pytest.mark.parametrize('metric', PROBABILISTIC_METRICS)
 @pytest.mark.parametrize('comparison', PROBABILISTIC_HINDCAST_COMPARISONS)
 def test_compute_hindcast_probabilistic(
-    initialized_da, observations_da, metric, comparison
+    hind_da_initialized_1d, observations_da_1d, metric, comparison
 ):
     """
     Checks that compute hindcast works without breaking.
     """
     if 'threshold' in metric:
-        threshold = 0.5  # initialized_da.mean()
+        threshold = 0.5  # hind_da_initialized_1d.mean()
     else:
         threshold = None
     if metric == 'brier_score':
@@ -105,8 +69,8 @@ def test_compute_hindcast_probabilistic(
     else:
         func = None
     res = compute_hindcast(
-        initialized_da,
-        observations_da,
+        hind_da_initialized_1d,
+        observations_da_1d,
         metric=metric,
         comparison=comparison,
         threshold=threshold,
@@ -123,7 +87,7 @@ def test_compute_hindcast_probabilistic(
 @pytest.mark.parametrize('comparison', PROBABILISTIC_PM_COMPARISONS)
 @pytest.mark.parametrize('metric', PROBABILISTIC_METRICS)
 def test_bootstrap_perfect_model_da1d_not_nan_probabilistic(
-    pm_da_ds1d, pm_da_control1d, metric, comparison
+    PM_da_initialized_1d, PM_da_control_1d, metric, comparison
 ):
     """
     Checks that there are no NaNs on perfect model probabilistic metrics of 1D
@@ -143,14 +107,14 @@ def test_bootstrap_perfect_model_da1d_not_nan_probabilistic(
         func = None
 
     actual = bootstrap_perfect_model(
-        pm_da_ds1d,
-        pm_da_control1d,
+        PM_da_initialized_1d,
+        PM_da_control_1d,
         comparison=comparison,
         metric=metric,
         threshold=threshold,
         gaussian=True,
         func=func,
-        bootstrap=3,
+        bootstrap=BOOTSTRAP,
         dim='member',
     )
     for kind in ['init', 'uninit']:
@@ -164,7 +128,11 @@ def test_bootstrap_perfect_model_da1d_not_nan_probabilistic(
 @pytest.mark.parametrize('comparison', PROBABILISTIC_HINDCAST_COMPARISONS)
 @pytest.mark.parametrize('metric', PROBABILISTIC_METRICS)
 def test_bootstrap_hindcast_da1d_not_nan_probabilistic(
-    initialized_da, uninitialized_da, observations_da, metric, comparison
+    hind_da_initialized_1d,
+    hind_da_uninitialized_1d,
+    observations_da_1d,
+    metric,
+    comparison,
 ):
     """
     Checks that there are no NaNs on hindcast probabilistic metrics of 1D
@@ -184,15 +152,15 @@ def test_bootstrap_hindcast_da1d_not_nan_probabilistic(
         func = None
 
     actual = bootstrap_hindcast(
-        initialized_da,
-        uninitialized_da,
-        observations_da,
+        hind_da_initialized_1d,
+        hind_da_uninitialized_1d,
+        observations_da_1d,
         comparison=comparison,
         metric=metric,
         threshold=threshold,
         gaussian=True,
         func=func,
-        bootstrap=3,
+        bootstrap=BOOTSTRAP,
         dim='member',
     )
     for kind in ['init', 'uninit']:
@@ -205,15 +173,15 @@ def test_bootstrap_hindcast_da1d_not_nan_probabilistic(
 
 @pytest.mark.skip(reason='takes quite long')
 def test_compute_perfect_model_da1d_not_nan_crpss_quadratic(
-    pm_da_ds1d, pm_da_control1d
+    PM_da_initialized_1d, PM_da_control_1d
 ):
     """
     Checks that there are no NaNs on perfect model metrics of 1D time series.
     """
     actual = (
         compute_perfect_model(
-            pm_da_ds1d,
-            pm_da_control1d,
+            PM_da_initialized_1d,
+            PM_da_control_1d,
             comparison='m2c',
             metric='crpss',
             gaussian=False,
@@ -226,14 +194,16 @@ def test_compute_perfect_model_da1d_not_nan_crpss_quadratic(
 
 
 @pytest.mark.skip(reason='takes quite long')
-def test_compute_hindcast_da1d_not_nan_crpss_quadratic(initialized_da, observations_da):
+def test_compute_hindcast_da1d_not_nan_crpss_quadratic(
+    hind_da_initialized_1d, observations_da_1d
+):
     """
     Checks that there are no NaNs on hindcast metrics of 1D time series.
     """
     actual = (
         compute_hindcast(
-            initialized_da,
-            observations_da,
+            hind_da_initialized_1d,
+            observations_da_1d,
             comparison='m2o',
             metric='crpss',
             gaussian=False,
@@ -245,24 +215,32 @@ def test_compute_hindcast_da1d_not_nan_crpss_quadratic(initialized_da, observati
     assert not actual
 
 
-def test_hindcast_crpss_orientation(initialized_da, observations_da):
+def test_hindcast_crpss_orientation(hind_da_initialized_1d, observations_da_1d):
     """
     Checks that CRPSS hindcast as skill score > 0.
     """
     actual = compute_hindcast(
-        initialized_da, observations_da, comparison='m2o', metric='crpss', dim='member'
+        hind_da_initialized_1d,
+        observations_da_1d,
+        comparison='m2o',
+        metric='crpss',
+        dim='member',
     )
     if 'init' in actual.coords:
         actual = actual.mean('init')
     assert not (actual.isel(lead=[0, 1]) < 0).any()
 
 
-def test_pm_crpss_orientation(pm_da_ds1d, pm_da_control1d):
+def test_pm_crpss_orientation(PM_da_initialized_1d, PM_da_control_1d):
     """
     Checks that CRPSS in PM as skill score > 0.
     """
     actual = compute_perfect_model(
-        pm_da_ds1d, pm_da_control1d, comparison='m2m', metric='crpss', dim='member'
+        PM_da_initialized_1d,
+        PM_da_control_1d,
+        comparison='m2m',
+        metric='crpss',
+        dim='member',
     )
     if 'init' in actual.coords:
         actual = actual.mean('init')
@@ -281,11 +259,14 @@ NON_PROBABILISTIC_PM_COMPARISONS = list(
 @pytest.mark.parametrize('comparison', NON_PROBABILISTIC_PM_COMPARISONS)
 @pytest.mark.parametrize('metric', PROBABILISTIC_METRICS)
 def test_compute_pm_probabilistic_metric_non_probabilistic_comparison_fails(
-    pm_da_ds1d, pm_da_control1d, metric, comparison
+    PM_da_initialized_1d, PM_da_control_1d, metric, comparison
 ):
     with pytest.raises(ValueError) as excinfo:
         compute_perfect_model(
-            pm_da_ds1d, pm_da_control1d, comparison=comparison, metric=metric
+            PM_da_initialized_1d,
+            PM_da_control_1d,
+            comparison=comparison,
+            metric=metric,
         )
     assert (
         f'Probabilistic metric {metric} cannot work with comparison {comparison}'
@@ -296,11 +277,15 @@ def test_compute_pm_probabilistic_metric_non_probabilistic_comparison_fails(
 @pytest.mark.parametrize('dim', ['init', ['init', 'member']])
 @pytest.mark.parametrize('metric', ['crps'])
 def test_compute_pm_probabilistic_metric_not_dim_member_warn(
-    pm_da_ds1d, pm_da_control1d, metric, dim
+    PM_da_initialized_1d, PM_da_control_1d, metric, dim
 ):
     with pytest.warns(UserWarning) as record:
         compute_perfect_model(
-            pm_da_ds1d, pm_da_control1d, comparison='m2c', metric=metric, dim=dim
+            PM_da_initialized_1d,
+            PM_da_control_1d,
+            comparison='m2c',
+            metric=metric,
+            dim=dim,
         )
     expected = (
         f'Probabilistic metric {metric} requires to be '
@@ -312,13 +297,13 @@ def test_compute_pm_probabilistic_metric_not_dim_member_warn(
 
 @pytest.mark.parametrize('metric', ['crps'])
 def test_compute_hindcast_probabilistic_metric_e2o_fails(
-    initialized_da, observations_da, metric
+    hind_da_initialized_1d, observations_da_1d, metric
 ):
     metric = METRIC_ALIASES.get(metric, metric)
     with pytest.raises(ValueError) as excinfo:
         compute_hindcast(
-            initialized_da,
-            observations_da,
+            hind_da_initialized_1d,
+            observations_da_1d,
             comparison='e2o',
             metric=metric,
             dim='member',
@@ -329,12 +314,16 @@ def test_compute_hindcast_probabilistic_metric_e2o_fails(
 @pytest.mark.parametrize('dim', ['init'])
 @pytest.mark.parametrize('metric', ['crps'])
 def test_compute_hindcast_probabilistic_metric_not_dim_member_warn(
-    initialized_da, observations_da, metric, dim
+    hind_da_initialized_1d, observations_da_1d, metric, dim
 ):
     metric = METRIC_ALIASES.get(metric, metric)
     with pytest.warns(UserWarning) as record:
         compute_hindcast(
-            initialized_da, observations_da, comparison='m2o', metric=metric, dim=dim
+            hind_da_initialized_1d,
+            observations_da_1d,
+            comparison='m2o',
+            metric=metric,
+            dim=dim,
         )
     expected = (
         f'Probabilistic metric {metric} requires to be '

--- a/climpred/tests/test_probabilistic.py
+++ b/climpred/tests/test_probabilistic.py
@@ -1,4 +1,5 @@
 import pytest
+from scipy.stats import norm
 
 from climpred.bootstrap import bootstrap_hindcast, bootstrap_perfect_model
 from climpred.constants import (
@@ -171,7 +172,6 @@ def test_bootstrap_hindcast_da1d_not_nan_probabilistic(
         assert not actualk
 
 
-@pytest.mark.skip(reason='takes quite long')
 def test_compute_perfect_model_da1d_not_nan_crpss_quadratic(
     PM_da_initialized_1d, PM_da_control_1d
 ):
@@ -180,12 +180,37 @@ def test_compute_perfect_model_da1d_not_nan_crpss_quadratic(
     """
     actual = (
         compute_perfect_model(
-            PM_da_initialized_1d,
+            PM_da_initialized_1d.isel(lead=[0]),
             PM_da_control_1d,
             comparison='m2c',
             metric='crpss',
             gaussian=False,
             dim='member',
+        )
+        .isnull()
+        .any()
+    )
+    assert not actual
+
+
+def test_compute_perfect_model_da1d_not_nan_crpss_quadratic_kwargs(
+    PM_da_initialized_1d, PM_da_control_1d
+):
+    """
+    Checks that there are no NaNs on perfect model metrics of 1D time series.
+    """
+    actual = (
+        compute_perfect_model(
+            PM_da_initialized_1d.isel(lead=[0]),
+            PM_da_control_1d,
+            comparison='m2c',
+            metric='crpss',
+            gaussian=False,
+            dim='member',
+            tol=1e-6,
+            xmin=None,
+            xmax=None,
+            cdf_or_dist=norm,
         )
         .isnull()
         .any()

--- a/climpred/tests/test_relative_entropy.py
+++ b/climpred/tests/test_relative_entropy.py
@@ -1,7 +1,3 @@
-import numpy as np
-import pytest
-import xarray as xr
-
 from climpred.graphics import plot_relative_entropy
 from climpred.relative_entropy import (
     bootstrap_relative_entropy,
@@ -9,61 +5,36 @@ from climpred.relative_entropy import (
 )
 
 
-@pytest.fixture
-def PM_da_ds3d():
-    lead = np.arange(1, 4)
-    lats = np.arange(4)
-    lons = np.arange(3)
-    member = np.arange(5)
-    init = [3004, 3009, 3015, 3023]
-    data = np.random.rand(len(lead), len(member), len(init), len(lats), len(lons))
-    da = xr.DataArray(
-        data,
-        coords=[lead, member, init, lats, lons],
-        dims=['lead', 'member', 'init', 'lat', 'lon'],
-    )
-    return da
-
-
-@pytest.fixture
-def PM_da_control3d():
-    dates = np.arange(3000, 3050)
-    lats = np.arange(4)
-    lons = np.arange(3)
-    data = np.random.rand(len(dates), len(lats), len(lons))
-    return xr.DataArray(data, coords=[dates, lats, lons], dims=['time', 'lat', 'lon'])
-
-
-def test_compute_relative_entropy(PM_da_ds3d, PM_da_control3d):
+def test_compute_relative_entropy(PM_da_initialized_3d, PM_da_control_3d):
     """
     Checks that there are no NaNs.
     """
     actual = compute_relative_entropy(
-        PM_da_ds3d, PM_da_control3d, nmember_control=5, neofs=2
+        PM_da_initialized_3d, PM_da_control_3d, nmember_control=5, neofs=2
     )
     actual_any_nan = actual.isnull().any()
     for var in actual_any_nan.data_vars:
         assert not actual_any_nan[var]
 
 
-def test_bootstrap_relative_entropy(PM_da_ds3d, PM_da_control3d):
+def test_bootstrap_relative_entropy(PM_da_initialized_3d, PM_da_control_3d):
     """
     Checks that there are no NaNs.
     """
     actual = bootstrap_relative_entropy(
-        PM_da_ds3d, PM_da_control3d, nmember_control=5, neofs=2, bootstrap=2
+        PM_da_initialized_3d, PM_da_control_3d, nmember_control=5, neofs=2, bootstrap=2,
     )
     actual_any_nan = actual.isnull()
     for var in actual_any_nan.data_vars:
         assert not actual_any_nan[var]
 
 
-def test_plot_relative_entropy(PM_da_ds3d, PM_da_control3d):
+def test_plot_relative_entropy(PM_da_initialized_3d, PM_da_control_3d):
     res = compute_relative_entropy(
-        PM_da_ds3d, PM_da_control3d, nmember_control=5, neofs=2
+        PM_da_initialized_3d, PM_da_control_3d, nmember_control=5, neofs=2
     )
     threshold = bootstrap_relative_entropy(
-        PM_da_ds3d, PM_da_control3d, nmember_control=5, neofs=2, bootstrap=2
+        PM_da_initialized_3d, PM_da_control_3d, nmember_control=5, neofs=2, bootstrap=2,
     )
     res_ax = plot_relative_entropy(res, threshold)
     assert res_ax is not None

--- a/climpred/tests/test_smoothing.py
+++ b/climpred/tests/test_smoothing.py
@@ -7,7 +7,6 @@ from climpred.smoothing import (
     spatial_smoothing_xrcoarsen,
     temporal_smoothing,
 )
-from climpred.tutorial import load_dataset
 
 try:
     from climpred.smoothing import spatial_smoothing_xesmf
@@ -17,94 +16,70 @@ except ImportError:
     xesmf_loaded = False
 
 
-@pytest.fixture
-def pm_da_control3d():
-    da = load_dataset('MPI-control-3D')
-    da = da['tos']
-    return da
-
-
-@pytest.fixture
-def pm_da_ds3d():
-    da = load_dataset('MPI-PM-DP-3D')
-    da = da['tos']
-    return da
-
-
-@pytest.fixture
-def fosi_3d():
-    ds = load_dataset('FOSI-SST-3D')
-    return ds
-
-
-@pytest.fixture
-def dple_3d():
-    ds = load_dataset('CESM-DP-SST-3D')
-    return ds
-
-
-def test_reset_temporal_axis(pm_da_control3d):
+def test_reset_temporal_axis(PM_da_control_3d_full):
     """Test whether correct new labels are set."""
     smooth = 10
     smooth_kws = {'time': smooth}
-    first_ori = pm_da_control3d.time[0].values
+    first_ori = PM_da_control_3d_full.time[0].values
     first_actual = _reset_temporal_axis(
-        pm_da_control3d, smooth_kws=smooth_kws
+        PM_da_control_3d_full, smooth_kws=smooth_kws
     ).time.values[0]
     first_expected = f'{first_ori}-{first_ori+smooth*1-1}'
     assert first_actual == first_expected
 
 
-def test_reset_temporal_axis_lead(pm_da_ds3d):
+def test_reset_temporal_axis_lead(PM_da_initialized_3d_full):
     """Test whether correct new labels are set."""
     smooth = 10
     dim = 'lead'
     smooth_kws = {dim: smooth}
-    first_ori = pm_da_ds3d.lead[0].values
-    first_actual = _reset_temporal_axis(pm_da_ds3d, smooth_kws=smooth_kws)[dim].values[
-        0
-    ]
+    first_ori = PM_da_initialized_3d_full.lead[0].values
+    first_actual = _reset_temporal_axis(
+        PM_da_initialized_3d_full, smooth_kws=smooth_kws
+    )[dim].values[0]
     first_expected = f'{first_ori}-{first_ori+smooth*1-1}'
     assert first_actual == first_expected
 
 
-def test_temporal_smoothing_reduce_length(pm_da_control3d):
+def test_temporal_smoothing_reduce_length(PM_da_control_3d_full):
     """Test whether dimsize is reduced properly."""
     smooth = 10
     smooth_kws = {'time': smooth}
-    actual = temporal_smoothing(pm_da_control3d, smooth_kws=smooth_kws).time.size
-    expected = pm_da_control3d.time.size - smooth + 1
+    actual = temporal_smoothing(PM_da_control_3d_full, smooth_kws=smooth_kws).time.size
+    expected = PM_da_control_3d_full.time.size - smooth + 1
     assert actual == expected
 
 
-def test_spatial_smoothing_xrcoarsen_reduce_spatial_dims(pm_da_control3d):
+def test_spatial_smoothing_xrcoarsen_reduce_spatial_dims(PM_da_control_3d_full,):
     """Test whether spatial dimsizes are properly reduced."""
-    da = pm_da_control3d
+    da = PM_da_control_3d_full
     coarsen_kws = {'x': 4, 'y': 2}
     actual = spatial_smoothing_xrcoarsen(da, coarsen_kws)
     for dim in coarsen_kws:
         actual_x = actual[dim].size
-        expected_x = pm_da_control3d[dim].size // coarsen_kws[dim]
+        expected_x = PM_da_control_3d_full[dim].size // coarsen_kws[dim]
         assert actual_x == expected_x
 
 
 def test_spatial_smoothing_xrcoarsen_reduce_spatial_dims_no_coarsen_kws(
-    pm_da_control3d,
+    PM_da_control_3d_full,
 ):
     """Test whether spatial dimsizes are properly reduced if no coarsen_kws
     given."""
-    da = pm_da_control3d
+    da = PM_da_control_3d_full
     coarsen_kws = {'x': 2, 'y': 2}
     actual = spatial_smoothing_xrcoarsen(da, coarsen_kws=None)
     for dim in coarsen_kws:
         actual_dim_size = actual[dim].size
-        expected_dim_size = pm_da_control3d[dim].size // coarsen_kws[dim]
+        expected_dim_size = PM_da_control_3d_full[dim].size // coarsen_kws[dim]
         assert actual_dim_size == expected_dim_size
 
 
-def test_spatial_smoothing_xrcoarsen_reduce_spatial_dims_CESM(fosi_3d):
+def test_spatial_smoothing_xrcoarsen_reduce_spatial_dims_CESM(
+    reconstruction_ds_3d_full,
+):
     """Test whether spatial dimsizes are properly reduced."""
-    da = fosi_3d.isel(nlon=slice(0, 24), nlat=slice(0, 36))
+    da = reconstruction_ds_3d_full.isel(nlon=slice(0, 24), nlat=slice(0, 36))
     coarsen_kws = {'nlon': 4, 'nlat': 4}
     actual = spatial_smoothing_xrcoarsen(da, coarsen_kws)
     for dim in coarsen_kws:
@@ -114,9 +89,9 @@ def test_spatial_smoothing_xrcoarsen_reduce_spatial_dims_CESM(fosi_3d):
 
 
 @pytest.mark.skipif(not xesmf_loaded, reason='xesmf not installed')
-def test_spatial_smoothing_xesmf_reduce_spatial_dims_MPI_curv(pm_da_control3d):
+def test_spatial_smoothing_xesmf_reduce_spatial_dims_MPI_curv(PM_da_control_3d_full,):
     """Test whether spatial dimsizes are properly reduced."""
-    da = pm_da_control3d
+    da = PM_da_control_3d_full
     step = 5
     actual = spatial_smoothing_xesmf(da, d_lon_lat_kws={'lon': step})
     expected_lat_size = 180 // step
@@ -125,9 +100,9 @@ def test_spatial_smoothing_xesmf_reduce_spatial_dims_MPI_curv(pm_da_control3d):
 
 
 @pytest.mark.skipif(not xesmf_loaded, reason='xesmf not installed')
-def test_spatial_smoothing_xesmf_reduce_spatial_dims_CESM(fosi_3d):
+def test_spatial_smoothing_xesmf_reduce_spatial_dims_CESM(reconstruction_ds_3d_full,):
     """Test whether spatial dimsizes are properly reduced."""
-    da = fosi_3d
+    da = reconstruction_ds_3d_full
     step = 0.1
     actual = spatial_smoothing_xesmf(da, d_lon_lat_kws={'lat': step})
     # test whether upsampled
@@ -135,10 +110,10 @@ def test_spatial_smoothing_xesmf_reduce_spatial_dims_CESM(fosi_3d):
     assert actual['lat'].size >= da.nlat.size
 
 
-def test_smooth_goddard_2013(pm_da_control3d):
+def test_smooth_goddard_2013(PM_da_control_3d_full):
     """Test whether Goddard 2013 recommendations are fulfilled by
     smooth_Goddard_2013."""
-    da = pm_da_control3d
+    da = PM_da_control_3d_full
     actual = smooth_goddard_2013(da)
     # test that x, y not in dims
     assert 'x' not in actual.dims
@@ -149,10 +124,12 @@ def test_smooth_goddard_2013(pm_da_control3d):
     assert actual.lat.size < da.lat.size
 
 
-def test_compute_after_smooth_goddard_2013(pm_da_ds3d, pm_da_control3d):
+def test_compute_after_smooth_goddard_2013(
+    PM_da_initialized_3d_full, PM_da_control_3d_full
+):
     """Test compute_perfect_model works after smoothings."""
-    pm_da_control3d = smooth_goddard_2013(pm_da_control3d)
-    pm_da_ds3d = smooth_goddard_2013(pm_da_ds3d)
-    actual = compute_perfect_model(pm_da_ds3d, pm_da_control3d)
+    PM_da_control_3d_full = smooth_goddard_2013(PM_da_control_3d_full)
+    PM_da_initialized_3d_full = smooth_goddard_2013(PM_da_initialized_3d_full)
+    actual = compute_perfect_model(PM_da_initialized_3d_full, PM_da_control_3d_full)
     north_atlantic = actual.sel(lat=slice(40, 50), lon=slice(-30, -20))
     assert not north_atlantic.isnull().any()

--- a/climpred/tests/test_stats.py
+++ b/climpred/tests/test_stats.py
@@ -15,37 +15,6 @@ from climpred.stats import (
     rm_trend,
     varweighted_mean_period,
 )
-from climpred.tutorial import load_dataset
-
-
-@pytest.fixture
-def two_dim_da():
-    da = xr.DataArray(
-        np.vstack(
-            [
-                np.arange(0, 5, 1.0),
-                np.arange(0, 10, 2.0),
-                np.arange(0, 40, 8.0),
-                np.arange(0, 20, 4.0),
-            ]
-        ),
-        dims=['row', 'col'],
-    )
-    return da
-
-
-@pytest.fixture
-def multi_dim_ds():
-    ds = xr.tutorial.open_dataset('air_temperature')
-    ds = ds.assign(**{'airx2': ds['air'] * 2})
-    return ds
-
-
-@pytest.fixture
-def control_3d_NA():
-    """North Atlantic"""
-    ds = load_dataset('MPI-control-3D')['tos'].isel(x=slice(110, 120), y=slice(50, 60))
-    return ds
 
 
 def test_rm_trend_missing_dim():
@@ -115,9 +84,9 @@ def test_rm_trend_3d_dataset_dim_order(multi_dim_ds):
 
 
 @pytest.mark.parametrize('chunk', (True, False))
-def test_dpp(control_3d_NA, chunk):
+def test_dpp(PM_da_control_3d, chunk):
     """Check for positive diagnostic potential predictability in NA SST."""
-    control = control_3d_NA
+    control = PM_da_control_3d
     res = dpp(control, chunk=chunk)
     assert res.mean() > 0
 
@@ -125,33 +94,33 @@ def test_dpp(control_3d_NA, chunk):
 @pytest.mark.parametrize(
     'func', (varweighted_mean_period, decorrelation_time, autocorr)
 )
-def test_potential_predictability_likely(control_3d_NA, func):
+def test_potential_predictability_likely(PM_da_control_3d, func):
     """Check for positive diagnostic potential predictability in NA SST."""
-    control = control_3d_NA
+    control = PM_da_control_3d
     print(control.dims)
     res = func(control)
     assert res.mean() > 0
 
 
-def test_autocorr(control_3d_NA):
+def test_autocorr(PM_da_control_3d):
     """Check autocorr results with scipy."""
-    ds = control_3d_NA.isel(x=5, y=5)
+    ds = PM_da_control_3d.isel(x=5, y=5)
     actual = autocorr(ds)
     expected = correlate(ds, ds)
     np.allclose(actual, expected)
 
 
-def test_corr(control_3d_NA):
+def test_corr(PM_da_control_3d):
     """Check autocorr results with scipy."""
-    ds = control_3d_NA.isel(x=5, y=5)
+    ds = PM_da_control_3d.isel(x=5, y=5)
     lag = 1
     actual = corr(ds, ds, lag=lag)
     expected = correlate(ds[:-lag], ds[lag:])
     np.allclose(actual, expected)
 
 
-def test_bootstrap_dpp_sig50_similar_dpp(control_3d_NA):
-    ds = control_3d_NA
+def test_bootstrap_dpp_sig50_similar_dpp(PM_da_control_3d):
+    ds = PM_da_control_3d
     bootstrap = 5
     sig = 50
     actual = dpp_threshold(ds, bootstrap=bootstrap, sig=sig).drop_vars('quantile')
@@ -159,8 +128,8 @@ def test_bootstrap_dpp_sig50_similar_dpp(control_3d_NA):
     xr.testing.assert_allclose(actual, expected, atol=0.5, rtol=0.5)
 
 
-def test_bootstrap_vwmp_sig50_similar_vwmp(control_3d_NA):
-    ds = control_3d_NA
+def test_bootstrap_vwmp_sig50_similar_vwmp(PM_da_control_3d):
+    ds = PM_da_control_3d
     bootstrap = 5
     sig = 50
     actual = varweighted_mean_period_threshold(
@@ -170,8 +139,8 @@ def test_bootstrap_vwmp_sig50_similar_vwmp(control_3d_NA):
     xr.testing.assert_allclose(actual, expected, atol=2, rtol=0.5)
 
 
-def test_bootstrap_func_multiple_sig_levels(control_3d_NA):
-    ds = control_3d_NA
+def test_bootstrap_func_multiple_sig_levels(PM_da_control_3d):
+    ds = PM_da_control_3d
     bootstrap = 5
     sig = [5, 95]
     actual = dpp_threshold(ds, bootstrap=bootstrap, sig=sig)
@@ -188,15 +157,15 @@ def test_bootstrap_func_multiple_sig_levels(control_3d_NA):
         pytest.param(decorrelation_time, marks=pytest.mark.xfail(reason='some bug')),
     ),
 )
-def test_stats_functions_dask_single_chunk(control_3d_NA, func):
+def test_stats_functions_dask_single_chunk(PM_da_control_3d, func):
     """Test stats functions when single chunk not along dim."""
     step = -1  # single chunk
-    for chunk_dim in control_3d_NA.dims:
-        control_chunked = control_3d_NA.chunk({chunk_dim: step})
-        for dim in control_3d_NA.dims:
+    for chunk_dim in PM_da_control_3d.dims:
+        control_chunked = PM_da_control_3d.chunk({chunk_dim: step})
+        for dim in PM_da_control_3d.dims:
             if dim != chunk_dim:
                 res_chunked = func(control_chunked, dim=dim)
-                res = func(control_3d_NA, dim=dim)
+                res = func(PM_da_control_3d, dim=dim)
                 # check for chunks
                 assert dask.is_dask_collection(res_chunked)
                 assert res_chunked.chunks is not None
@@ -214,20 +183,20 @@ def test_stats_functions_dask_single_chunk(control_3d_NA, func):
         autocorr,
         varweighted_mean_period,
         pytest.param(
-            decorrelation_time, marks=pytest.mark.xfail(reason='some chunking bug')
+            decorrelation_time, marks=pytest.mark.xfail(reason='some chunking bug'),
         ),
     ],
 )
-def test_stats_functions_dask_many_chunks(control_3d_NA, func):
+def test_stats_functions_dask_many_chunks(PM_da_control_3d, func):
     """Check whether selected stats functions be chunked in multiple chunks and
      computed along other dim."""
     step = 1
-    for chunk_dim in control_3d_NA.dims:
-        control_chunked = control_3d_NA.chunk({chunk_dim: step})
-        for dim in control_3d_NA.dims:
+    for chunk_dim in PM_da_control_3d.dims:
+        control_chunked = PM_da_control_3d.chunk({chunk_dim: step})
+        for dim in PM_da_control_3d.dims:
             if dim != chunk_dim and dim in control_chunked.dims:
                 res_chunked = func(control_chunked, dim=dim)
-                res = func(control_3d_NA, dim=dim)
+                res = func(PM_da_control_3d, dim=dim)
                 # check for chunks
                 assert dask.is_dask_collection(res_chunked)
                 assert res_chunked.chunks is not None
@@ -238,20 +207,20 @@ def test_stats_functions_dask_many_chunks(control_3d_NA, func):
                 assert_allclose(res, res_chunked.compute())
 
 
-def test_varweighted_mean_period_dim(control_3d_NA):
+def test_varweighted_mean_period_dim(PM_da_control_3d):
     """Test varweighted_mean_period for different dims."""
-    for d in control_3d_NA.dims:
+    for d in PM_da_control_3d.dims:
         # single dim
-        varweighted_mean_period(control_3d_NA, dim=d)
+        varweighted_mean_period(PM_da_control_3d, dim=d)
         # all but one dim
-        di = [di for di in control_3d_NA.dims if di != d]
-        varweighted_mean_period(control_3d_NA, dim=di)
+        di = [di for di in PM_da_control_3d.dims if di != d]
+        varweighted_mean_period(PM_da_control_3d, dim=di)
 
 
 @pytest.mark.xfail(reason='p value not aligned in the two functions.')
-def test_corr_autocorr(control_3d_NA):
-    res1 = corr(control_3d_NA, control_3d_NA, lag=1, return_p=True)
-    res2 = autocorr(control_3d_NA, return_p=True)
+def test_corr_autocorr(PM_da_control_3d):
+    res1 = corr(PM_da_control_3d, PM_da_control_3d, lag=1, return_p=True)
+    res2 = autocorr(PM_da_control_3d, return_p=True)
     for i in [0, 1]:
         print(res1[i] - res2[i])
         assert_allclose(res1[i], res2[i])

--- a/climpred/tests/test_utils.py
+++ b/climpred/tests/test_utils.py
@@ -23,14 +23,14 @@ from climpred.utils import (
 
 
 @pytest.fixture
-def control_ds_3d():
+def PM_ds_control_3d():
     """North Atlantic xr.Dataset."""
     ds = load_dataset('MPI-control-3D').sel(x=slice(120, 130), y=slice(50, 60))
     return ds
 
 
 @pytest.fixture
-def control_da_3d():
+def PM_da_control_3d():
     """North Atlantic xr.DataArray."""
     da = load_dataset('MPI-control-3D').sel(x=slice(120, 130), y=slice(50, 60))['tos']
     return da
@@ -125,7 +125,7 @@ def test_bootstrap_pm_assign_attrs():
     da = load_dataset('MPI-PM-DP-1D')[v].isel(area=1, period=-1)
     control = load_dataset('MPI-control-1D')[v].isel(area=1, period=-1)
     actual = bootstrap_perfect_model(
-        da, control, metric=metric, comparison=comparison, bootstrap=bootstrap, sig=sig
+        da, control, metric=metric, comparison=comparison, bootstrap=bootstrap, sig=sig,
     ).attrs
     assert actual['metric'] == metric
     assert actual['comparison'] == comparison
@@ -150,38 +150,38 @@ def test_hindcast_assign_attrs():
     assert actual['skill_calculated_by_function'] == 'compute_hindcast'
 
 
-def test_copy_coords_from_to_ds(control_ds_3d):
+def test_copy_coords_from_to_ds(PM_ds_control_3d):
     """Test whether coords are copied from one xr object to another."""
     #
-    xro = control_ds_3d
+    xro = PM_ds_control_3d
     c_1time = xro.isel(time=4).drop_vars('time')
     assert 'time' not in c_1time.coords
     c_1time = copy_coords_from_to(xro.isel(time=2), c_1time)
     assert (c_1time.time == xro.isel(time=2).time).all()
 
 
-def test_copy_coords_from_to_da(control_da_3d):
+def test_copy_coords_from_to_da(PM_da_control_3d):
     """Test whether coords are copied from one xr object to another."""
     #
-    xro = control_da_3d
+    xro = PM_da_control_3d
     c_1time = xro.isel(time=4).drop_vars('time')
     assert 'time' not in c_1time.coords
     c_1time = copy_coords_from_to(xro.isel(time=2), c_1time)
     assert (c_1time.time == xro.isel(time=2).time).all()
 
 
-def test_copy_coords_from_to_ds_chunk(control_ds_3d):
+def test_copy_coords_from_to_ds_chunk(PM_ds_control_3d):
     """Test whether coords are copied from one xr object to another."""
     #
-    xro = control_ds_3d.chunk({'time': 5})
+    xro = PM_ds_control_3d.chunk({'time': 5})
     c_1time = xro.isel(time=4).drop_vars('time')
     assert 'time' not in c_1time.coords
     c_1time = copy_coords_from_to(xro.isel(time=2), c_1time)
     assert (c_1time.time == xro.isel(time=2).time).all()
 
 
-def test_copy_coords_from_to_da_different_xro(control_ds_3d):
-    xro = control_ds_3d.chunk({'time': 5})
+def test_copy_coords_from_to_da_different_xro(PM_ds_control_3d):
+    xro = PM_ds_control_3d.chunk({'time': 5})
     c_1time = xro.isel(time=4).drop_vars('time')
     with pytest.raises(ValueError) as excinfo:
         copy_coords_from_to(xro.isel(time=2).tos, c_1time)

--- a/climpred/tests/test_utils.py
+++ b/climpred/tests/test_utils.py
@@ -22,20 +22,6 @@ from climpred.utils import (
 )
 
 
-@pytest.fixture
-def PM_ds_control_3d():
-    """North Atlantic xr.Dataset."""
-    ds = load_dataset('MPI-control-3D').sel(x=slice(120, 130), y=slice(50, 60))
-    return ds
-
-
-@pytest.fixture
-def PM_da_control_3d():
-    """North Atlantic xr.DataArray."""
-    da = load_dataset('MPI-control-3D').sel(x=slice(120, 130), y=slice(50, 60))['tos']
-    return da
-
-
 def test_get_metric_class():
     """Test if passing in a string gets the right metric function."""
     actual = get_metric_class('pearson_r', DETERMINISTIC_PM_METRICS).name

--- a/climpred/tests/test_versioning.py
+++ b/climpred/tests/test_versioning.py
@@ -1,5 +1,12 @@
-from climpred.versioning.print_versions import show_versions
+import pytest
+
+from climpred.versioning.print_versions import main, show_versions
 
 
-def test_show_versions():
-    show_versions()
+@pytest.mark.parametrize('as_json', [True, False])
+def test_show_versions(as_json):
+    show_versions(as_json=as_json)
+
+
+def test_main():
+    main()

--- a/climpred/tests/test_xarray_methods.py
+++ b/climpred/tests/test_xarray_methods.py
@@ -1,15 +1,3 @@
-import pytest
-
-from climpred.tutorial import load_dataset
-
-
-@pytest.fixture
-def initialized_ds():
-    da = load_dataset('CESM-DP-SST')
-    da = da - da.mean('init')
-    return da
-
-
-def test_drop_vars(initialized_ds):
+def test_drop_vars(hind_ds_initialized_1d):
     """Tests that ds.drop_vars() from version 0.14.1 of xarray works."""
-    assert initialized_ds.drop_vars('lead')
+    assert hind_ds_initialized_1d.drop_vars('lead')


### PR DESCRIPTION
# Description

Problem: 
 - we duplicate code in `tests`
 - identical fixtures have different names in different files

Solution:
 - pytest.fixtures are refactored into `conftest.py` which pytest automatically includes, see https://docs.pytest.org/en/latest/fixture.html
 - docstrings added to each fixture


Benefit:
 - cleaner testing code
 - testing of fixtured class objects


Fixes #306 

## Type of change

refactor

# How Has This Been Tested?

pytest

## Checklist (while developing)

-   [x]  I have added docstrings to all new functions.
-   [x]  I have commented my code, particularly in hard-to-understand areas
-   [x]  Tests added for `pytest`, if necessary.

## Pre-Merge Checklist (final steps)

-   [ ]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

## References

Please add any references to manuscripts, textbooks, etc.
