### PR TITLE
remove circular dependencies

### DIFF
--- a/climpred/bootstrap.py
+++ b/climpred/bootstrap.py
@@ -5,7 +5,8 @@ import xarray as xr
 from tqdm.auto import tqdm
 
 from .checks import has_dims, has_valid_lead_units
-from .constants import ALL_COMPARISONS, ALL_METRICS, COMPARISON_ALIASES, METRIC_ALIASES
+from .comparisons import ALL_COMPARISONS, COMPARISON_ALIASES
+from .metrics import ALL_METRICS, METRIC_ALIASES
 from .prediction import compute_hindcast, compute_perfect_model, compute_persistence
 from .stats import dpp, varweighted_mean_period
 from .utils import (
@@ -148,7 +149,7 @@ def bootstrap_uninit_pm_ensemble_from_control(ds, control):
     def create_pseudo_members(control):
         startlist = np.random.randint(c_start, c_end - length - 1, nmember)
         return xr.concat(
-            (isel_years(control, start, length) for start in startlist), 'member'
+            (isel_years(control, start, length) for start in startlist), 'member',
         )
 
     return xr.concat((create_pseudo_members(control) for _ in range(nens)), 'init')
@@ -222,7 +223,7 @@ def varweighted_mean_period_threshold(control, sig=95, bootstrap=500, time_dim='
         * climpred.stats.varweighted_mean_period
     """
     return _bootstrap_func(
-        varweighted_mean_period, control, time_dim, sig=sig, bootstrap=bootstrap
+        varweighted_mean_period, control, time_dim, sig=sig, bootstrap=bootstrap,
     )
 
 
@@ -417,7 +418,7 @@ def bootstrap_compute(
 
     # calc mean skill without any resampling
     init_skill = compute(
-        hind, verif, metric=metric, comparison=comparison, dim=dim, **metric_kwargs
+        hind, verif, metric=metric, comparison=comparison, dim=dim, **metric_kwargs,
     )
     if 'init' in init_skill:
         init_skill = init_skill.mean('init')

--- a/climpred/checks.py
+++ b/climpred/checks.py
@@ -3,14 +3,14 @@ from functools import wraps
 
 import xarray as xr
 
+# VALID_LEAD_UNITS = ['years', 'seasons', 'months', 'weeks', 'pentads', 'days']
+from .constants import VALID_LEAD_UNITS
 from .exceptions import DatasetError, DimensionError, VariableError
-
-# the import of CLIMPRED_DIMS from constants fails. currently fixed manually.
-VALID_LEAD_UNITS = ['years', 'seasons', 'months', 'weeks', 'pentads', 'days']
-
 
 # https://stackoverflow.com/questions/10610824/
 # python-shortcut-for-writing-decorators-which-accept-arguments
+
+
 def dec_args_kwargs(wrapper):
     return lambda *dec_args, **dec_kwargs: lambda func: wrapper(
         func, *dec_args, **dec_kwargs

--- a/climpred/checks.py
+++ b/climpred/checks.py
@@ -3,15 +3,13 @@ from functools import wraps
 
 import xarray as xr
 
-# VALID_LEAD_UNITS = ['years', 'seasons', 'months', 'weeks', 'pentads', 'days']
 from .constants import VALID_LEAD_UNITS
 from .exceptions import DatasetError, DimensionError, VariableError
 
-# https://stackoverflow.com/questions/10610824/
-# python-shortcut-for-writing-decorators-which-accept-arguments
-
 
 def dec_args_kwargs(wrapper):
+    # https://stackoverflow.com/questions/10610824/
+    # python-shortcut-for-writing-decorators-which-accept-arguments
     return lambda *dec_args, **dec_kwargs: lambda func: wrapper(
         func, *dec_args, **dec_kwargs
     )

--- a/climpred/comparisons.py
+++ b/climpred/comparisons.py
@@ -2,10 +2,10 @@ import numpy as np
 import xarray as xr
 
 from .checks import has_dims, has_min_len
+from .constants import M2M_MEMBER_DIM
 from .exceptions import DimensionError
 
-# from .constants import M2M_MEMBER_DIM
-M2M_MEMBER_DIM = 'forecast_member'
+# M2M_MEMBER_DIM = 'forecast_member'
 
 
 def _drop_members(ds, removed_member=None):
@@ -52,7 +52,7 @@ class Comparison:
     """Master class for all comparisons."""
 
     def __init__(
-        self, name, function, hindcast, probabilistic, long_name=None, aliases=None
+        self, name, function, hindcast, probabilistic, long_name=None, aliases=None,
     ):
         """Comparison initialization.
 
@@ -313,3 +313,28 @@ __m2o = Comparison(
 
 
 __ALL_COMPARISONS__ = [__m2m, __m2e, __m2c, __e2c, __e2o, __m2o]
+
+COMPARISON_ALIASES = dict()
+for c in __ALL_COMPARISONS__:
+    if c.aliases is not None:
+        for a in c.aliases:
+            COMPARISON_ALIASES[a] = c.name
+
+# Which comparisons work with which set of metrics.
+# ['e2o', 'm2o']
+HINDCAST_COMPARISONS = [c.name for c in __ALL_COMPARISONS__ if c.hindcast]
+# ['m2c', 'e2c', 'm2m', 'm2e']
+PM_COMPARISONS = [c.name for c in __ALL_COMPARISONS__ if not c.hindcast]
+ALL_COMPARISONS = HINDCAST_COMPARISONS + PM_COMPARISONS
+# ['m2c', 'm2m']
+PROBABILISTIC_PM_COMPARISONS = [
+    c.name for c in __ALL_COMPARISONS__ if (not c.hindcast and c.probabilistic)
+]
+# ['m2o']
+PROBABILISTIC_HINDCAST_COMPARISONS = [
+    c.name for c in __ALL_COMPARISONS__ if (c.hindcast and c.probabilistic)
+]
+PROBABILISTIC_COMPARISONS = (
+    PROBABILISTIC_HINDCAST_COMPARISONS + PROBABILISTIC_PM_COMPARISONS
+)
+ALL_COMPARISONS = [c.name for c in __ALL_COMPARISONS__]

--- a/climpred/comparisons.py
+++ b/climpred/comparisons.py
@@ -5,8 +5,6 @@ from .checks import has_dims, has_min_len
 from .constants import M2M_MEMBER_DIM
 from .exceptions import DimensionError
 
-# M2M_MEMBER_DIM = 'forecast_member'
-
 
 def _drop_members(ds, removed_member=None):
     """

--- a/climpred/constants.py
+++ b/climpred/constants.py
@@ -1,7 +1,5 @@
 # name for additional dimension in m2m comparison
 M2M_MEMBER_DIM = 'forecast_member'
-FORECAST_MEMBER_DIM = 'forecast_member'
-
 
 # for general checks of climpred-required dimensions
 CLIMPRED_ENSEMBLE_DIMS = ['init', 'member', 'lead']

--- a/climpred/constants.py
+++ b/climpred/constants.py
@@ -1,56 +1,7 @@
-from .comparisons import __ALL_COMPARISONS__ as all_comparisons
-from .metrics import __ALL_METRICS__ as all_metrics
-
-# To match a metric/comparison for (multiple) keywords.
-METRIC_ALIASES = dict()
-for m in all_metrics:
-    if m.aliases is not None:
-        for a in m.aliases:
-            METRIC_ALIASES[a] = m.name
-
-COMPARISON_ALIASES = dict()
-for c in all_comparisons:
-    if c.aliases is not None:
-        for a in c.aliases:
-            COMPARISON_ALIASES[a] = c.name
-
-DETERMINISTIC_METRICS = [m.name for m in all_metrics if not m.probabilistic]
-DETERMINISTIC_HINDCAST_METRICS = DETERMINISTIC_METRICS
-# Metrics to be used in compute_perfect_model.
-DETERMINISTIC_PM_METRICS = DETERMINISTIC_HINDCAST_METRICS.copy()
-# Used to set attrs['units'] to None.
-DIMENSIONLESS_METRICS = [m.name for m in all_metrics if m.unit_power == 1]
-# More positive skill is better than more negative.
-POSITIVELY_ORIENTED_METRICS = [m.name for m in all_metrics if m.positive]
-PROBABILISTIC_METRICS = [m.name for m in all_metrics if m.probabilistic]
-
-# Combined allowed metrics for compute_hindcast and compute_perfect_model
-HINDCAST_METRICS = DETERMINISTIC_HINDCAST_METRICS + PROBABILISTIC_METRICS
-PM_METRICS = DETERMINISTIC_PM_METRICS + PROBABILISTIC_METRICS
-ALL_METRICS = (
-    DETERMINISTIC_HINDCAST_METRICS + DETERMINISTIC_PM_METRICS + PROBABILISTIC_METRICS
-)
-
-# Which comparisons work with which set of metrics.
-# ['e2o', 'm2o']
-HINDCAST_COMPARISONS = [c.name for c in all_comparisons if c.hindcast]
-# ['m2c', 'e2c', 'm2m', 'm2e']
-PM_COMPARISONS = [c.name for c in all_comparisons if not c.hindcast]
-ALL_COMPARISONS = HINDCAST_COMPARISONS + PM_COMPARISONS
-# ['m2c', 'm2m']
-PROBABILISTIC_PM_COMPARISONS = [
-    c.name for c in all_comparisons if (not c.hindcast and c.probabilistic)
-]
-# ['m2o']
-PROBABILISTIC_HINDCAST_COMPARISONS = [
-    c.name for c in all_comparisons if (c.hindcast and c.probabilistic)
-]
-PROBABILISTIC_COMPARISONS = (
-    PROBABILISTIC_HINDCAST_COMPARISONS + PROBABILISTIC_PM_COMPARISONS
-)
-
 # name for additional dimension in m2m comparison
+M2M_MEMBER_DIM = 'forecast_member'
 FORECAST_MEMBER_DIM = 'forecast_member'
+
 
 # for general checks of climpred-required dimensions
 CLIMPRED_ENSEMBLE_DIMS = ['init', 'member', 'lead']

--- a/climpred/graphics.py
+++ b/climpred/graphics.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import matplotlib.pyplot as plt
 import numpy as np
 
-from .constants import PROBABILISTIC_METRICS
+from .metrics import PROBABILISTIC_METRICS
 
 
 def plot_relative_entropy(rel_ent, rel_ent_threshold=None, **kwargs):
@@ -41,7 +41,7 @@ def plot_relative_entropy(rel_ent, rel_ent_threshold=None, **kwargs):
             ls='--',
         )
         ax[i].plot(
-            rel_ent.lead, (m + std), c=colors[i], label='', linewidth=2.5, ls='--'
+            rel_ent.lead, (m + std), c=colors[i], label='', linewidth=2.5, ls='--',
         )
         if rel_ent_threshold is not None:
             ax[i].axhline(
@@ -191,9 +191,7 @@ def plot_bootstrapped_skill_over_leadyear(
                 fmt='--o',
                 capsize=capsize,
                 c=c_pers,
-                label=(' ').join(
-                    ['persistence with', str(pers_sig) + '%', 'confidence interval']
-                ),
+                label=f'persistence with {pers_sig}% confidence interval',
             )
         for t in pers_skill.lead.values:
             ax.text(

--- a/climpred/metrics.py
+++ b/climpred/metrics.py
@@ -22,11 +22,11 @@ from xskillscore import (
     threshold_brier_score,
 )
 
+# the import of CLIMPRED_DIMS from constants fails. currently fixed manually.
+from .constants import CLIMPRED_DIMS
 from .np_metrics import _effective_sample_size as ess, _spearman_r_eff_p_value as srepv
 
-# the import of CLIMPRED_DIMS from constants fails. currently fixed manually.
-# from .constants import CLIMPRED_DIMS
-CLIMPRED_DIMS = ['init', 'member', 'lead', 'time']
+# CLIMPRED_DIMS = ['init', 'member', 'lead', 'time']
 
 
 def _get_norm_factor(comparison):
@@ -2201,3 +2201,27 @@ __ALL_METRICS__ = [
     __uacc,
     __std_ratio,
 ]
+
+
+# To match a metric/comparison for (multiple) keywords.
+METRIC_ALIASES = dict()
+for m in __ALL_METRICS__:
+    if m.aliases is not None:
+        for a in m.aliases:
+            METRIC_ALIASES[a] = m.name
+
+
+DETERMINISTIC_METRICS = [m.name for m in __ALL_METRICS__ if not m.probabilistic]
+DETERMINISTIC_HINDCAST_METRICS = DETERMINISTIC_METRICS
+# Metrics to be used in compute_perfect_model.
+DETERMINISTIC_PM_METRICS = DETERMINISTIC_HINDCAST_METRICS.copy()
+# Used to set attrs['units'] to None.
+DIMENSIONLESS_METRICS = [m.name for m in __ALL_METRICS__ if m.unit_power == 1]
+# More positive skill is better than more negative.
+POSITIVELY_ORIENTED_METRICS = [m.name for m in __ALL_METRICS__ if m.positive]
+PROBABILISTIC_METRICS = [m.name for m in __ALL_METRICS__ if m.probabilistic]
+
+# Combined allowed metrics for compute_hindcast and compute_perfect_model
+HINDCAST_METRICS = DETERMINISTIC_HINDCAST_METRICS + PROBABILISTIC_METRICS
+PM_METRICS = DETERMINISTIC_PM_METRICS + PROBABILISTIC_METRICS
+ALL_METRICS = [m.name for m in __ALL_METRICS__]

--- a/climpred/metrics.py
+++ b/climpred/metrics.py
@@ -22,11 +22,8 @@ from xskillscore import (
     threshold_brier_score,
 )
 
-# the import of CLIMPRED_DIMS from constants fails. currently fixed manually.
 from .constants import CLIMPRED_DIMS
 from .np_metrics import _effective_sample_size as ess, _spearman_r_eff_p_value as srepv
-
-# CLIMPRED_DIMS = ['init', 'member', 'lead', 'time']
 
 
 def _get_norm_factor(comparison):

--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -6,7 +6,7 @@ import xarray as xr
 
 from .checks import has_valid_lead_units, is_in_list, is_xarray
 from .comparisons import COMPARISON_ALIASES, HINDCAST_COMPARISONS, PM_COMPARISONS, __e2c
-from .constants import CLIMPRED_DIMS
+from .constants import CLIMPRED_DIMS, M2M_MEMBER_DIM
 from .metrics import (
     DETERMINISTIC_HINDCAST_METRICS,
     HINDCAST_METRICS,
@@ -25,8 +25,6 @@ from .utils import (
     shift_cftime_index,
 )
 
-# from .constants import M2M_MEMBER_DIM
-M2M_MEMBER_DIM = 'forecast_member'
 
 # --------------------------------------------#
 # COMPUTE PREDICTABILITY/FORECASTS

--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -5,15 +5,12 @@ import dask
 import xarray as xr
 
 from .checks import has_valid_lead_units, is_in_list, is_xarray
-from .comparisons import __e2c
-from .constants import (
-    CLIMPRED_DIMS,
-    COMPARISON_ALIASES,
+from .comparisons import COMPARISON_ALIASES, HINDCAST_COMPARISONS, PM_COMPARISONS, __e2c
+from .constants import CLIMPRED_DIMS
+from .metrics import (
     DETERMINISTIC_HINDCAST_METRICS,
-    HINDCAST_COMPARISONS,
     HINDCAST_METRICS,
     METRIC_ALIASES,
-    PM_COMPARISONS,
     PM_METRICS,
 )
 from .utils import (

--- a/climpred/tests/test_comparisons.py
+++ b/climpred/tests/test_comparisons.py
@@ -5,6 +5,8 @@ from xarray.testing import assert_equal
 
 from climpred.comparisons import (
     __ALL_COMPARISONS__ as all_comparisons,
+    PM_COMPARISONS,
+    PROBABILISTIC_PM_COMPARISONS,
     Comparison,
     __e2c,
     __m2c,
@@ -12,8 +14,7 @@ from climpred.comparisons import (
     __m2m,
     _drop_members,
 )
-from climpred.constants import PM_COMPARISONS, PM_METRICS, PROBABILISTIC_PM_COMPARISONS
-from climpred.metrics import __mse as metric
+from climpred.metrics import PM_METRICS, __mse as metric
 from climpred.prediction import compute_perfect_model
 from climpred.tutorial import load_dataset
 from climpred.utils import get_comparison_class, get_metric_class

--- a/climpred/tests/test_compute_dims.py
+++ b/climpred/tests/test_compute_dims.py
@@ -2,13 +2,12 @@ import pytest
 from xarray.testing import assert_allclose
 
 from climpred.bootstrap import bootstrap_hindcast, bootstrap_perfect_model
-from climpred.constants import (
+from climpred.comparisons import (
     PM_COMPARISONS,
-    PM_METRICS,
     PROBABILISTIC_HINDCAST_COMPARISONS,
-    PROBABILISTIC_METRICS,
     PROBABILISTIC_PM_COMPARISONS,
 )
+from climpred.metrics import PM_METRICS, PROBABILISTIC_METRICS
 from climpred.prediction import compute_hindcast, compute_perfect_model
 from climpred.tutorial import load_dataset
 from climpred.utils import get_comparison_class, get_metric_class
@@ -70,7 +69,7 @@ def test_pm_comparison_stack_dims_when_deterministic(pm_da_ds1d, comparison, met
 def test_compute_perfect_model_dim_over_member(pm_da_ds1d, pm_da_control1d, comparison):
     """Test deterministic metric calc skill over member dim."""
     actual = compute_perfect_model(
-        pm_da_ds1d, pm_da_control1d, comparison=comparison, metric='rmse', dim='member'
+        pm_da_ds1d, pm_da_control1d, comparison=comparison, metric='rmse', dim='member',
     )
     assert 'init' in actual.dims
     assert not actual.isnull().any()
@@ -103,7 +102,7 @@ def test_compute_perfect_model_different_dims_quite_close(pm_da_ds1d, pm_da_cont
         dim=['init', 'member'],
     )
     stack_dims_false = compute_perfect_model(
-        pm_da_ds1d, pm_da_control1d, comparison='m2c', metric='rmse', dim='member'
+        pm_da_ds1d, pm_da_control1d, comparison='m2c', metric='rmse', dim='member',
     ).mean(['init'])
     # no more than 10% difference
     assert_allclose(stack_dims_true, stack_dims_false, rtol=0.1, atol=0.03)
@@ -157,7 +156,7 @@ def test_compute_pm_dims(pm_da_ds1d, pm_da_control1d, dim, comparison, metric):
     """Test whether compute_pm calcs skill over all possible dims
     and comparisons and just reduces the result by dim."""
     actual = compute_perfect_model(
-        pm_da_ds1d, pm_da_control1d, metric=metric, dim=dim, comparison=comparison
+        pm_da_ds1d, pm_da_control1d, metric=metric, dim=dim, comparison=comparison,
     )
     # change dim as automatically in compute functions for probabilistic
     if dim in ['init', ['init', 'member']] and metric in PROBABILISTIC_METRICS:
@@ -180,7 +179,7 @@ def test_compute_hindcast_dims(
     """Test whether compute_hindcast calcs skill over all possible dims
     and comparisons and just reduces the result by dim."""
     actual = compute_hindcast(
-        initialized_da, observations_da, metric=metric, dim=dim, comparison=comparison
+        initialized_da, observations_da, metric=metric, dim=dim, comparison=comparison,
     )
     # change dim as automatically in compute functions for probabilistic
     if dim == 'init' and metric in PROBABILISTIC_METRICS:

--- a/climpred/tests/test_effective_p_value.py
+++ b/climpred/tests/test_effective_p_value.py
@@ -1,6 +1,6 @@
 import pytest
 
-from climpred.constants import HINDCAST_COMPARISONS, PM_COMPARISONS
+from climpred.comparisons import HINDCAST_COMPARISONS, PM_COMPARISONS
 from climpred.prediction import compute_hindcast, compute_perfect_model
 from climpred.tutorial import load_dataset
 

--- a/climpred/tests/test_hindcast_prediction.py
+++ b/climpred/tests/test_hindcast_prediction.py
@@ -3,11 +3,9 @@ import numpy as np
 import pytest
 
 from climpred.bootstrap import bootstrap_hindcast
-from climpred.constants import (
-    CLIMPRED_DIMS,
-    DETERMINISTIC_HINDCAST_METRICS,
-    HINDCAST_COMPARISONS,
-)
+from climpred.comparisons import HINDCAST_COMPARISONS
+from climpred.constants import CLIMPRED_DIMS
+from climpred.metrics import DETERMINISTIC_HINDCAST_METRICS
 from climpred.prediction import (
     compute_hindcast,
     compute_persistence,
@@ -126,7 +124,7 @@ def test_compute_hindcast(initialized_ds, reconstruction_ds, metric, comparison)
     """
     res = (
         compute_hindcast(
-            initialized_ds, reconstruction_ds, metric=metric, comparison=comparison
+            initialized_ds, reconstruction_ds, metric=metric, comparison=comparison,
         )
         .isnull()
         .any()
@@ -146,7 +144,7 @@ def test_compute_hindcast_lead0_lead1(
         initialized_ds, reconstruction_ds, metric='rmse', comparison='e2o'
     )
     res2 = compute_hindcast(
-        initialized_ds_lead0, reconstruction_ds, metric='rmse', comparison='e2o'
+        initialized_ds_lead0, reconstruction_ds, metric='rmse', comparison='e2o',
     )
     assert (res1.SST.values == res2.SST.values).all()
 
@@ -182,7 +180,7 @@ def test_uninitialized(uninitialized_da, reconstruction_da):
     """
     res = (
         compute_uninitialized(
-            uninitialized_da, reconstruction_da, metric='rmse', comparison='e2o'
+            uninitialized_da, reconstruction_da, metric='rmse', comparison='e2o',
         )
         .isnull()
         .any()
@@ -232,7 +230,7 @@ def test_compute_hindcast_comparison_keyerrors(
     """
     with pytest.raises(KeyError) as excinfo:
         compute_hindcast(
-            initialized_ds, reconstruction_ds, comparison=comparison, metric='mse'
+            initialized_ds, reconstruction_ds, comparison=comparison, metric='mse',
         )
     assert 'Specify comparison from' in str(excinfo.value)
 

--- a/climpred/tests/test_metrics.py
+++ b/climpred/tests/test_metrics.py
@@ -5,7 +5,7 @@ import xskillscore as xs
 from xarray.testing import assert_allclose
 
 from climpred.bootstrap import bootstrap_perfect_model
-from climpred.constants import PM_COMPARISONS
+from climpred.comparisons import PM_COMPARISONS
 from climpred.metrics import __ALL_METRICS__ as all_metrics, Metric, __pearson_r
 from climpred.prediction import compute_hindcast, compute_perfect_model
 from climpred.tutorial import load_dataset
@@ -169,7 +169,7 @@ def test_pm_metric_weights_m2x(ds_3d_NA, control_3d_NA, comparison, metric):
     )
     weights = xr.DataArray(np.arange(1, 1 + ds_3d_NA[dim].size), dims=dim)
     weights = xr.DataArray(
-        np.arange(1, 1 + ds_3d_NA[dim].size * ds_3d_NA['member'].size), dims='init'
+        np.arange(1, 1 + ds_3d_NA[dim].size * ds_3d_NA['member'].size), dims='init',
     )
 
     weighted = compute_perfect_model(
@@ -191,10 +191,10 @@ def test_hindcast_metric_skipna(initialized_da, reconstruction_da, metric):
     # manipulating data
     initialized_da.isel(init=0, lead=0, nlat=2, nlon=2).values = np.nan
     base = compute_hindcast(
-        initialized_da, reconstruction_da, metric=metric, skipna=False, dim='init'
+        initialized_da, reconstruction_da, metric=metric, skipna=False, dim='init',
     )
     skipping = compute_hindcast(
-        initialized_da, reconstruction_da, metric=metric, skipna=True, dim='init'
+        initialized_da, reconstruction_da, metric=metric, skipna=True, dim='init',
     )
     assert ((base / skipping) != 1).any()
 
@@ -205,7 +205,11 @@ def test_hindcast_metric_weights(initialized_da, reconstruction_da, comparison, 
     # distribute weights on initializations
     dim = 'init'
     base = compute_hindcast(
-        initialized_da, reconstruction_da, dim=dim, metric=metric, comparison=comparison
+        initialized_da,
+        reconstruction_da,
+        dim=dim,
+        metric=metric,
+        comparison=comparison,
     )
     weights = xr.DataArray(
         np.arange(1, 1 + initialized_da[dim].size - initialized_da.lead.size),
@@ -232,7 +236,11 @@ def test_hindcast_metric_weights_x2r(
     # distribute weights on initializations
     dim = 'init'
     base = compute_hindcast(
-        initialized_da, reconstruction_da, dim=dim, metric=metric, comparison=comparison
+        initialized_da,
+        reconstruction_da,
+        dim=dim,
+        metric=metric,
+        comparison=comparison,
     )
     weights = xr.DataArray(np.arange(1, 1 + initialized_da[dim].size), dims=dim)
     weights = xr.DataArray(

--- a/climpred/tests/test_perfect_model_prediction.py
+++ b/climpred/tests/test_perfect_model_prediction.py
@@ -2,7 +2,8 @@ import dask
 import pytest
 
 from climpred.bootstrap import bootstrap_perfect_model
-from climpred.constants import CLIMPRED_DIMS, DETERMINISTIC_PM_METRICS
+from climpred.constants import CLIMPRED_DIMS
+from climpred.metrics import DETERMINISTIC_PM_METRICS
 from climpred.prediction import compute_perfect_model, compute_persistence
 from climpred.tutorial import load_dataset
 
@@ -238,7 +239,7 @@ def test_compute_pm_dask_climpred_dims(ds_3d_NA, control_3d_NA, comparison, metr
         if dim in control_3d_NA.dims:
             control_3d_NA = control_3d_NA.chunk({dim: step})
         res_chunked = compute_perfect_model(
-            ds_3d_NA, control_3d_NA, comparison=comparison, metric=metric, dim='init'
+            ds_3d_NA, control_3d_NA, comparison=comparison, metric=metric, dim='init',
         )
         # check for chunks
         assert dask.is_dask_collection(res_chunked)

--- a/climpred/tests/test_probabilistic.py
+++ b/climpred/tests/test_probabilistic.py
@@ -1,13 +1,12 @@
 import pytest
 
 from climpred.bootstrap import bootstrap_hindcast, bootstrap_perfect_model
-from climpred.constants import (
-    METRIC_ALIASES,
+from climpred.comparisons import (
     PM_COMPARISONS,
     PROBABILISTIC_HINDCAST_COMPARISONS,
-    PROBABILISTIC_METRICS,
     PROBABILISTIC_PM_COMPARISONS,
 )
+from climpred.metrics import METRIC_ALIASES, PROBABILISTIC_METRICS
 from climpred.prediction import compute_hindcast, compute_perfect_model
 from climpred.tutorial import load_dataset
 
@@ -250,7 +249,7 @@ def test_hindcast_crpss_orientation(initialized_da, observations_da):
     Checks that CRPSS hindcast as skill score > 0.
     """
     actual = compute_hindcast(
-        initialized_da, observations_da, comparison='m2o', metric='crpss', dim='member'
+        initialized_da, observations_da, comparison='m2o', metric='crpss', dim='member',
     )
     if 'init' in actual.coords:
         actual = actual.mean('init')
@@ -262,7 +261,7 @@ def test_pm_crpss_orientation(pm_da_ds1d, pm_da_control1d):
     Checks that CRPSS in PM as skill score > 0.
     """
     actual = compute_perfect_model(
-        pm_da_ds1d, pm_da_control1d, comparison='m2m', metric='crpss', dim='member'
+        pm_da_ds1d, pm_da_control1d, comparison='m2m', metric='crpss', dim='member',
     )
     if 'init' in actual.coords:
         actual = actual.mean('init')
@@ -300,7 +299,7 @@ def test_compute_pm_probabilistic_metric_not_dim_member_warn(
 ):
     with pytest.warns(UserWarning) as record:
         compute_perfect_model(
-            pm_da_ds1d, pm_da_control1d, comparison='m2c', metric=metric, dim=dim
+            pm_da_ds1d, pm_da_control1d, comparison='m2c', metric=metric, dim=dim,
         )
     expected = (
         f'Probabilistic metric {metric} requires to be '
@@ -334,7 +333,7 @@ def test_compute_hindcast_probabilistic_metric_not_dim_member_warn(
     metric = METRIC_ALIASES.get(metric, metric)
     with pytest.warns(UserWarning) as record:
         compute_hindcast(
-            initialized_da, observations_da, comparison='m2o', metric=metric, dim=dim
+            initialized_da, observations_da, comparison='m2o', metric=metric, dim=dim,
         )
     expected = (
         f'Probabilistic metric {metric} requires to be '

--- a/climpred/tests/test_utils.py
+++ b/climpred/tests/test_utils.py
@@ -6,9 +6,8 @@ import xarray as xr
 from xarray.testing import assert_allclose
 
 from climpred.bootstrap import bootstrap_perfect_model
-from climpred.comparisons import __m2c
-from climpred.constants import DETERMINISTIC_PM_METRICS, PM_COMPARISONS
-from climpred.metrics import __pearson_r
+from climpred.comparisons import PM_COMPARISONS, __m2c
+from climpred.metrics import DETERMINISTIC_PM_METRICS, __pearson_r
 from climpred.prediction import compute_hindcast, compute_perfect_model
 from climpred.tutorial import load_dataset
 from climpred.utils import (
@@ -125,7 +124,7 @@ def test_bootstrap_pm_assign_attrs():
     da = load_dataset('MPI-PM-DP-1D')[v].isel(area=1, period=-1)
     control = load_dataset('MPI-control-1D')[v].isel(area=1, period=-1)
     actual = bootstrap_perfect_model(
-        da, control, metric=metric, comparison=comparison, bootstrap=bootstrap, sig=sig
+        da, control, metric=metric, comparison=comparison, bootstrap=bootstrap, sig=sig,
     ).attrs
     assert actual['metric'] == metric
     assert actual['comparison'] == comparison

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -9,7 +9,8 @@ from xarray.coding.cftime_offsets import to_offset
 
 from . import comparisons, metrics
 from .checks import is_in_list
-from .constants import COMPARISON_ALIASES, METRIC_ALIASES
+from .comparisons import COMPARISON_ALIASES
+from .metrics import METRIC_ALIASES
 
 
 def convert_time_index(xobj, time_string, kind):
@@ -155,9 +156,11 @@ def get_lead_cftime_shift_args(units, lead):
     lead = int(lead)
 
     d = {
-        'years': (lead, 'YS'),  # Currently assumes yearly aligns with year start.
+        # Currently assumes yearly aligns with year start.
+        'years': (lead, 'YS'),
         'seasons': (lead * 3, 'MS'),
-        'months': (lead, 'MS'),  # Currently assumes monthly aligns with month start.
+        # Currently assumes monthly aligns with month start.
+        'months': (lead, 'MS'),
         'weeks': (lead * 7, 'D'),
         'pentads': (lead * 5, 'D'),
         'days': (lead, 'D'),


### PR DESCRIPTION
# Description

Problem:
- `metrics` imported `CLIMPRED_DIMS` from `constants` but `constants` also imported `__ALL_METRICS__` from `metrics`
- same goes for `comparisons`

Solution:
- `ALL_METRICS` loop inside `metrics`, same for `comparison`

Downside:
- `constants` gets rather empty
- more import lines typically needed in all modules

Fixes # couple of #TODO's in the code

## Type of change

refactor

# How Has This Been Tested?

pytest

## Pre-Merge Checklist (final steps)

-   [x]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

## References

Please add any references to manuscripts, textbooks, etc.
