### PR TITLE
get rid of .values

### DIFF
--- a/climpred/bootstrap.py
+++ b/climpred/bootstrap.py
@@ -147,7 +147,7 @@ def bootstrap_uninitialized_ensemble(hind, hist):
 
     uninit_hind = []
     for init in hind.init:
-        random_members = dask.array.random.choice(hist.member, hind.member.size)
+        random_members = np.random.choice(hist.member, hind.member.size)
         # take random uninitialized members from hist at init forcing
         # (Goddard allows 5 year forcing range here)
         # TODO: implement these 5 years

--- a/climpred/bootstrap.py
+++ b/climpred/bootstrap.py
@@ -35,8 +35,8 @@ def _resample(hind, resample_dim):
         xr.object: resampled along `resample_dim`.
 
     """
-    smp = np.random.choice(hind[resample_dim], hind[resample_dim].size)
-    smp_hind = hind.sel({resample_dim: smp})
+    smp = np.random.choice(np.arange(hind[resample_dim].size), hind[resample_dim].size)
+    smp_hind = hind.isel({resample_dim: smp})
     # ignore because then inits should keep their labels
     if resample_dim != 'init':
         smp_hind[resample_dim] = hind[resample_dim]

--- a/climpred/tests/conftest.py
+++ b/climpred/tests/conftest.py
@@ -107,6 +107,7 @@ def perfectModelEnsemble_initialized_control(PM_ds_initialized_1d, PM_ds_control
 def hind_ds_initialized_1d():
     """CESM-DPLE initialized hindcast timeseries mean removed xr.Dataset."""
     da = load_dataset('CESM-DP-SST')
+    da['init'] = da.init.astype('int32')
     return da - da.mean('init')
 
 

--- a/climpred/tests/test_bootstrap.py
+++ b/climpred/tests/test_bootstrap.py
@@ -99,6 +99,7 @@ def test_bootstrap_hindcast_lazy(
 def test_bootstrap_hindcast_resample_dim(
     hind_da_initialized_1d, hist_da_uninitialized_1d, observations_da_1d, resample_dim
 ):
+    print(hind_da_initialized_1d)
     bootstrap_hindcast(
         hind_da_initialized_1d,
         hist_da_uninitialized_1d,

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -262,6 +262,7 @@ def intersect(lst1, lst2):
     """
     Custom intersection, since `set.intersection()` changes type of list.
     """
+    # TODO: make this work on xarray coords
     lst3 = [value for value in lst1 if value in lst2]
     return np.array(lst3)
 


### PR DESCRIPTION
# Description

- get rid of .values
- get rid of 1+1,ds[dim].size
- tried to exchange dask.array.random for np.random: got difficulties
    - also dask.array.random in the end wraps np.random
    - therefore np.random faster than da.random


Closes #(issue)

## Type of change

Please delete options that are not relevant.

-   [ ]  Bug fix (non-breaking change which fixes an issue)
-   [ ]  New feature (non-breaking change which adds functionality)
-   [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ]  This change requires a documentation update
-   [ ]  Performance (if you touched existing code run `asv` to detect performance changes)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here.

## Checklist (while developing)

-   [ ]  I have added docstrings to all new functions.
-   [ ]  I have commented my code, particularly in hard-to-understand areas
-   [ ]  Tests added for `pytest`, if necessary.
-   [ ]  I have updated the sphinx documentation, if necessary.

## Pre-Merge Checklist (final steps)

-   [ ]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

## References

Please add any references to manuscripts, textbooks, etc.
