### PR TITLE
logging to verify different verification schemes in compute hindcast

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,18 @@ New Features
 
     *  user gets warned when chunking potentially (un)-necessary
 - new explicit keywords in bootstrap functions for ``resampling_dim`` and
-  ``baseline_compute`` (:pr:`320`) `Aaron Spring`_.
+  ``reference_compute`` (:pr:`320`) `Aaron Spring`_.
+- new explicit keywords for ``common`` including logging for testing this
+  verification time matching (:pr:`324`) `Aaron Spring`_.
+
+    * max_dof/None: maximize the degrees of freedom by slicing ``hind`` and
+      ``verif`` to a common time frame at each lead.
+    * inits: slice to a common init frame prior to computing
+      metric. This philosophy follows the thought that each lead should be based
+      on the same set of initializations.
+    * verif: slice to a common/consistent verification time frame prior to
+      computing metric. This philosophy follows the thought that each lead
+      should be based on the same set of initializations.
 
 
 Internals/Minor Fixes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,16 +18,16 @@ New Features
     *  user gets warned when chunking potentially (un)-necessary
 - new explicit keywords in bootstrap functions for ``resampling_dim`` and
   ``reference_compute`` (:pr:`320`) `Aaron Spring`_.
-- new explicit keywords for ``common`` including logging for testing this
+- new explicit keywords for ``alignment`` including logging for testing this
   verification time matching (:pr:`324`) `Aaron Spring`_.
 
-    * max_dof/None: maximize the degrees of freedom by slicing ``hind`` and
+    * maximize/None: maximize the degrees of freedom by slicing ``hind`` and
       ``verif`` to a common time frame at each lead.
-    * inits: slice to a common init frame prior to computing
-      metric. This philosophy follows the thought that each lead should be based
-      on the same set of initializations.
-    * verif: slice to a common/consistent verification time frame prior to
-      computing metric. This philosophy follows the thought that each lead
+    * same_inits: slice to a common init frame prior to computing
+      metric. This philosophy follows the thought that each lead should be
+      based on the same set of initializations.
+    * same_verif: slice to a common/consistent verification time frame prior
+      to computing metric. This philosophy follows the thought that each lead
       should be based on the same set of verification dates.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,7 +28,7 @@ New Features
       on the same set of initializations.
     * verif: slice to a common/consistent verification time frame prior to
       computing metric. This philosophy follows the thought that each lead
-      should be based on the same set of initializations.
+      should be based on the same set of verification dates.
 
 
 Internals/Minor Fixes

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -848,7 +848,7 @@ class HindcastEnsemble(PredictionEnsemble):
                 based on the same set of initializations.
                 - verif: slice to a common/consistent verification time frame prior to
                 computing metric. This philosophy follows the thought that each lead
-                should be based on the same set of initializations.
+                should be based on the same set of verification dates.
 
         Returns:
             Dataset of comparison results (if comparing to one observational product),
@@ -886,7 +886,7 @@ class HindcastEnsemble(PredictionEnsemble):
                 based on the same set of initializations.
                 - verif: slice to a common/consistent verification time frame prior to
                 computing metric. This philosophy follows the thought that each lead
-                should be based on the same set of initializations.
+                should be based on the same set of verification dates.
 
         Returns:
             Dataset of comparison results (if comparing to one observational product),
@@ -937,7 +937,7 @@ class HindcastEnsemble(PredictionEnsemble):
                 based on the same set of initializations.
                 - verif: slice to a common/consistent verification time frame prior to
                 computing metric. This philosophy follows the thought that each lead
-                should be based on the same set of initializations.
+                should be based on the same set of verification dates.
 
         Returns:
             Dataset of persistence forecast results (if ``name`` is not ``None``),

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -801,8 +801,15 @@ class HindcastEnsemble(PredictionEnsemble):
                 observations/verification data. ('e2o' for ensemble mean to
                 observations/verification data. 'm2o' for each individual member to
                 observations/verification data).
-            maximize (bool, default False): If ``True``, maximize the degrees of freedom
-                for each lag calculation.
+            alignment (str): which inits or verification times should be aligned?
+                - maximize/None: maximize the degrees of freedom by slicing ``hind`` and
+                ``verif`` to a common time frame at each lead.
+                - same_inits: slice to a common init frame prior to computing
+                metric. This philosophy follows the thought that each lead should be
+                based on the same set of initializations.
+                - same_verif: slice to a common/consistent verification time frame prior
+                to computing metric. This philosophy follows the thought that each lead
+                should be based on the same set of verification dates.
 
         Returns:
             Dataset of comparison results (if comparing to one observational product),

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -786,7 +786,7 @@ class HindcastEnsemble(PredictionEnsemble):
     # Analysis Functions
     # ------------------
     def verify(
-        self, name=None, metric='pearson_r', comparison='e2o', alignment='inits'
+        self, name=None, metric='pearson_r', comparison='e2o', alignment='same_inits'
     ):
         """Verifies the initialized ensemble against observations/verification data.
 
@@ -827,7 +827,7 @@ class HindcastEnsemble(PredictionEnsemble):
         )
 
     def compute_metric(
-        self, name=None, metric='pearson_r', comparison='e2o', alignment='inits'
+        self, name=None, metric='pearson_r', comparison='e2o', alignment='same_inits'
     ):
         """Verifies the initialized ensemble against observations/verification data.
 
@@ -845,11 +845,11 @@ class HindcastEnsemble(PredictionEnsemble):
             alignment (str): which inits or verification times should be aligned?
                 - maximize/None: maximize the degrees of freedom by slicing ``hind`` and
                 ``verif`` to a common time frame at each lead.
-                - inits: slice to a common init frame prior to computing
+                - same_inits: slice to a common init frame prior to computing
                 metric. This philosophy follows the thought that each lead should be
                 based on the same set of initializations.
-                - verif: slice to a common/consistent verification time frame prior to
-                computing metric. This philosophy follows the thought that each lead
+                - same_verif: slice to a common/consistent verification time frame prior
+                to computing metric. This philosophy follows the thought that each lead
                 should be based on the same set of verification dates.
 
         Returns:
@@ -883,11 +883,11 @@ class HindcastEnsemble(PredictionEnsemble):
             alignment (str): which inits or verification times should be aligned?
                 - maximize/None: maximize the degrees of freedom by slicing ``hind`` and
                 ``verif`` to a common time frame at each lead.
-                - inits: slice to a common init frame prior to computing
+                - same_inits: slice to a common init frame prior to computing
                 metric. This philosophy follows the thought that each lead should be
                 based on the same set of initializations.
-                - verif: slice to a common/consistent verification time frame prior to
-                computing metric. This philosophy follows the thought that each lead
+                - same_verif: slice to a common/consistent verification time frame prior
+                to computing metric. This philosophy follows the thought that each lead
                 should be based on the same set of verification dates.
 
         Returns:
@@ -913,7 +913,9 @@ class HindcastEnsemble(PredictionEnsemble):
             comparison=comparison,
         )
 
-    def compute_persistence(self, name=None, metric='pearson_r', alignment='inits'):
+    def compute_persistence(
+        self, name=None, metric='pearson_r', alignment='same_inits'
+    ):
         """Verify against a persistence forecast of the observations/verification data.
 
         This simply applies some metric between the observational product and itself out
@@ -934,11 +936,11 @@ class HindcastEnsemble(PredictionEnsemble):
             alignment (str): which inits or verification times should be aligned?
                 - maximize/None: maximize the degrees of freedom by slicing ``hind`` and
                 ``verif`` to a common time frame at each lead.
-                - inits: slice to a common init frame prior to computing
+                - same_inits: slice to a common init frame prior to computing
                 metric. This philosophy follows the thought that each lead should be
                 based on the same set of initializations.
-                - verif: slice to a common/consistent verification time frame prior to
-                computing metric. This philosophy follows the thought that each lead
+                - same_verif: slice to a common/consistent verification time frame prior
+                to computing metric. This philosophy follows the thought that each lead
                 should be based on the same set of verification dates.
 
         Returns:

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -785,7 +785,7 @@ class HindcastEnsemble(PredictionEnsemble):
     # ------------------
     # Analysis Functions
     # ------------------
-    def verify(self, name=None, metric='pearson_r', comparison='e2o', max_dof=False):
+    def verify(self, name=None, metric='pearson_r', comparison='e2o', common='inits'):
         """Verifies the initialized ensemble against observations/verification data.
 
         This will automatically verify against all shared variables
@@ -821,11 +821,11 @@ class HindcastEnsemble(PredictionEnsemble):
             input_dict=input_dict,
             metric=metric,
             comparison=comparison,
-            max_dof=max_dof,
+            common=common,
         )
 
     def compute_metric(
-        self, name=None, metric='pearson_r', comparison='e2o', max_dof=False
+        self, name=None, metric='pearson_r', comparison='e2o', common='inits'
     ):
         """Verifies the initialized ensemble against observations/verification data.
 
@@ -840,8 +840,15 @@ class HindcastEnsemble(PredictionEnsemble):
                 observations/verification data. ('e2o'
                 for ensemble mean to observations/verification data.
                 'm2o' for each individual member to observations/verification data).
-            max_dof (bool, default False): If ``True``, maximize the degrees of freedom
-                for each lag calculation.
+            common (str): which inits or verification times should be aligned?
+                - max_dof/None: maximize the degrees of freedom by slicing ``hind`` and
+                ``verif`` to a common time frame at each lead.
+                - inits: slice to a common init frame prior to computing
+                metric. This philosophy follows the thought that each lead should be
+                based on the same set of initializations.
+                - verif: slice to a common/consistent verification time frame prior to
+                computing metric. This philosophy follows the thought that each lead
+                should be based on the same set of initializations.
 
         Returns:
             Dataset of comparison results (if comparing to one observational product),
@@ -854,7 +861,7 @@ class HindcastEnsemble(PredictionEnsemble):
             PendingDeprecationWarning,
         )
         return self.verify(
-            name=name, metric=metric, comparison=comparison, max_dof=max_dof
+            name=name, metric=metric, comparison=comparison, common=common
         )
 
     def compute_uninitialized(self, name=None, metric='pearson_r', comparison='e2o'):
@@ -871,8 +878,15 @@ class HindcastEnsemble(PredictionEnsemble):
                 observations/verification data. ('e2o' for ensemble mean to
                 observations/verification data. 'm2o' for each individual member to
                 observations/verification data).
-            max_dof (bool, default False): If ``True``, maximize the degrees of freedom
-                for each lag calculation.
+            common (str): which inits or verification times should be aligned?
+                - max_dof/None: maximize the degrees of freedom by slicing ``hind`` and
+                ``verif`` to a common time frame at each lead.
+                - inits: slice to a common init frame prior to computing
+                metric. This philosophy follows the thought that each lead should be
+                based on the same set of initializations.
+                - verif: slice to a common/consistent verification time frame prior to
+                computing metric. This philosophy follows the thought that each lead
+                should be based on the same set of initializations.
 
         Returns:
             Dataset of comparison results (if comparing to one observational product),
@@ -897,7 +911,7 @@ class HindcastEnsemble(PredictionEnsemble):
             comparison=comparison,
         )
 
-    def compute_persistence(self, name=None, metric='pearson_r', max_dof=False):
+    def compute_persistence(self, name=None, metric='pearson_r', common='inits'):
         """Verify against a persistence forecast of the observations/verification data.
 
         This simply applies some metric between the observational product and itself out
@@ -915,8 +929,15 @@ class HindcastEnsemble(PredictionEnsemble):
                 with which to compute the persistence forecast. If ``None``, compute
                 for all observations/verification data.
             metric (str, default 'pearson_r'): Metric to apply for verification.
-            max_dof (bool, default False): If ``True``, maximize the degrees of freedom
-                for each lag calculation.
+            common (str): which inits or verification times should be aligned?
+                - max_dof/None: maximize the degrees of freedom by slicing ``hind`` and
+                ``verif`` to a common time frame at each lead.
+                - inits: slice to a common init frame prior to computing
+                metric. This philosophy follows the thought that each lead should be
+                based on the same set of initializations.
+                - verif: slice to a common/consistent verification time frame prior to
+                computing metric. This philosophy follows the thought that each lead
+                should be based on the same set of initializations.
 
         Returns:
             Dataset of persistence forecast results (if ``name`` is not ``None``),
@@ -940,5 +961,5 @@ class HindcastEnsemble(PredictionEnsemble):
             'init': True,
         }
         return self._apply_climpred_function(
-            compute_persistence, input_dict=input_dict, metric=metric, max_dof=max_dof
+            compute_persistence, input_dict=input_dict, metric=metric, common=common
         )

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -785,7 +785,9 @@ class HindcastEnsemble(PredictionEnsemble):
     # ------------------
     # Analysis Functions
     # ------------------
-    def verify(self, name=None, metric='pearson_r', comparison='e2o', common='inits'):
+    def verify(
+        self, name=None, metric='pearson_r', comparison='e2o', alignment='inits'
+    ):
         """Verifies the initialized ensemble against observations/verification data.
 
         This will automatically verify against all shared variables
@@ -799,7 +801,7 @@ class HindcastEnsemble(PredictionEnsemble):
                 observations/verification data. ('e2o' for ensemble mean to
                 observations/verification data. 'm2o' for each individual member to
                 observations/verification data).
-            max_dof (bool, default False): If ``True``, maximize the degrees of freedom
+            maximize (bool, default False): If ``True``, maximize the degrees of freedom
                 for each lag calculation.
 
         Returns:
@@ -821,11 +823,11 @@ class HindcastEnsemble(PredictionEnsemble):
             input_dict=input_dict,
             metric=metric,
             comparison=comparison,
-            common=common,
+            alignment=alignment,
         )
 
     def compute_metric(
-        self, name=None, metric='pearson_r', comparison='e2o', common='inits'
+        self, name=None, metric='pearson_r', comparison='e2o', alignment='inits'
     ):
         """Verifies the initialized ensemble against observations/verification data.
 
@@ -840,8 +842,8 @@ class HindcastEnsemble(PredictionEnsemble):
                 observations/verification data. ('e2o'
                 for ensemble mean to observations/verification data.
                 'm2o' for each individual member to observations/verification data).
-            common (str): which inits or verification times should be aligned?
-                - max_dof/None: maximize the degrees of freedom by slicing ``hind`` and
+            alignment (str): which inits or verification times should be aligned?
+                - maximize/None: maximize the degrees of freedom by slicing ``hind`` and
                 ``verif`` to a common time frame at each lead.
                 - inits: slice to a common init frame prior to computing
                 metric. This philosophy follows the thought that each lead should be
@@ -861,7 +863,7 @@ class HindcastEnsemble(PredictionEnsemble):
             PendingDeprecationWarning,
         )
         return self.verify(
-            name=name, metric=metric, comparison=comparison, common=common
+            name=name, metric=metric, comparison=comparison, alignment=alignment
         )
 
     def compute_uninitialized(self, name=None, metric='pearson_r', comparison='e2o'):
@@ -878,8 +880,8 @@ class HindcastEnsemble(PredictionEnsemble):
                 observations/verification data. ('e2o' for ensemble mean to
                 observations/verification data. 'm2o' for each individual member to
                 observations/verification data).
-            common (str): which inits or verification times should be aligned?
-                - max_dof/None: maximize the degrees of freedom by slicing ``hind`` and
+            alignment (str): which inits or verification times should be aligned?
+                - maximize/None: maximize the degrees of freedom by slicing ``hind`` and
                 ``verif`` to a common time frame at each lead.
                 - inits: slice to a common init frame prior to computing
                 metric. This philosophy follows the thought that each lead should be
@@ -911,7 +913,7 @@ class HindcastEnsemble(PredictionEnsemble):
             comparison=comparison,
         )
 
-    def compute_persistence(self, name=None, metric='pearson_r', common='inits'):
+    def compute_persistence(self, name=None, metric='pearson_r', alignment='inits'):
         """Verify against a persistence forecast of the observations/verification data.
 
         This simply applies some metric between the observational product and itself out
@@ -929,8 +931,8 @@ class HindcastEnsemble(PredictionEnsemble):
                 with which to compute the persistence forecast. If ``None``, compute
                 for all observations/verification data.
             metric (str, default 'pearson_r'): Metric to apply for verification.
-            common (str): which inits or verification times should be aligned?
-                - max_dof/None: maximize the degrees of freedom by slicing ``hind`` and
+            alignment (str): which inits or verification times should be aligned?
+                - maximize/None: maximize the degrees of freedom by slicing ``hind`` and
                 ``verif`` to a common time frame at each lead.
                 - inits: slice to a common init frame prior to computing
                 metric. This philosophy follows the thought that each lead should be
@@ -961,5 +963,8 @@ class HindcastEnsemble(PredictionEnsemble):
             'init': True,
         }
         return self._apply_climpred_function(
-            compute_persistence, input_dict=input_dict, metric=metric, common=common
+            compute_persistence,
+            input_dict=input_dict,
+            metric=metric,
+            alignment=alignment,
         )

--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -236,10 +236,11 @@ def compute_hindcast(
         # Take real time verification data using real time forecast dates.
         b = verif.sel(time=a.time.values)
 
-        logging.info(
-            f'at lead={str(i).zfill(2)}: dim={dim}: {a.time.min().values}-'
-            f'{a.time.max().values}'
-        )
+        if a.time.size > 0:
+            logging.info(
+                f'at lead={str(i).zfill(2)}: dim={dim}: {a.time.min().values}-'
+                f'{a.time.max().values}'
+            )
 
         # adapt weights to shorter time
         if 'weights' in metric_kwargs:

--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -132,7 +132,7 @@ def compute_hindcast(
     metric='pearson_r',
     comparison='e2o',
     dim='init',
-    alignment='inits',
+    alignment='same_inits',
     add_attrs=True,
     **metric_kwargs,
 ):
@@ -159,10 +159,10 @@ def compute_hindcast(
         alignment (str): which inits or verification times should be aligned?
             - maximize/None: maximize the degrees of freedom by slicing ``hind`` and
             ``verif`` to a common time frame at each lead.
-            - inits: slice to a common init frame prior to computing
+            - same_inits: slice to a common init frame prior to computing
             metric. This philosophy follows the thought that each lead should be based
             on the same set of initializations.
-            - verif: slice to a common/consistent verification time frame prior to
+            - same_verif: slice to a common/consistent verification time frame prior to
             computing metric. This philosophy follows the thought that each lead
             should be based on the same set of verification dates.
         add_attrs (bool): write climpred compute args to attrs. default: True
@@ -222,7 +222,7 @@ def compute_hindcast(
         verif = verif.chunk({'time': -1})
 
     # take only inits for which we have verification data at all leads
-    if alignment == 'inits':
+    if alignment == 'same_inits':
         forecast, verif = reduce_time_series_for_aligned_inits(forecast, verif, nlags)
 
     plag = []
@@ -284,7 +284,7 @@ def compute_hindcast(
 
 @is_xarray([0, 1])
 def compute_persistence(
-    hind, verif, metric='pearson_r', alignment='inits', **metric_kwargs
+    hind, verif, metric='pearson_r', alignment='same_inits', **metric_kwargs
 ):
     """Computes the skill of a persistence forecast from a simulation.
 
@@ -296,10 +296,10 @@ def compute_persistence(
         alignment (str): which inits or verification times should be aligned?
             - maximize/None: maximize the degrees of freedom by slicing ``hind`` and
             ``verif`` to a common time frame at each lead.
-            - inits: slice to a common init frame prior to computing
+            - same_inits: slice to a common init frame prior to computing
             metric. This philosophy follows the thought that each lead should be based
             on the same set of initializations.
-            - verif: slice to a common/consistent verification time frame prior to
+            - same_verif: slice to a common/consistent verification time frame prior to
             computing metric. This philosophy follows the thought that each lead
             should be based on the same set of verification dates.
         ** metric_kwargs (dict): additional keywords to be passed to metric

--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -164,7 +164,7 @@ def compute_hindcast(
             on the same set of initializations.
             - verif: slice to a common/consistent verification time frame prior to
             computing metric. This philosophy follows the thought that each lead
-            should be based on the same set of initializations.
+            should be based on the same set of verification dates.
         add_attrs (bool): write climpred compute args to attrs. default: True
         ** metric_kwargs (dict): additional keywords to be passed to metric
             (see the arguments required for a given metric in :ref:`Metrics`).
@@ -301,7 +301,7 @@ def compute_persistence(
             on the same set of initializations.
             - verif: slice to a common/consistent verification time frame prior to
             computing metric. This philosophy follows the thought that each lead
-            should be based on the same set of initializations.
+            should be based on the same set of verification dates.
         ** metric_kwargs (dict): additional keywords to be passed to metric
             (see the arguments required for a given metric in :ref:`Metrics`).
 

--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -14,7 +14,7 @@ from .metrics import (
     METRIC_ALIASES,
     PM_METRICS,
 )
-from .utils import (  # reduce_time_series_for_aligned_verifs,
+from .utils import (
     assign_attrs,
     convert_time_index,
     copy_coords_from_to,

--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -237,8 +237,8 @@ def compute_hindcast(
         b = verif.sel(time=a.time.values)
 
         logging.info(
-            f'at lead={i}: dim={dim}: {a.time.min().dt.year.values}-'
-            f'{a.time.max().dt.year.values}'
+            f'at lead={str(i).zfill(2)}: dim={dim}: {a.time.min().values}-'
+            f'{a.time.max().values}'
         )
 
         # adapt weights to shorter time

--- a/climpred/prediction.py
+++ b/climpred/prediction.py
@@ -1,4 +1,5 @@
 import inspect
+import logging
 import warnings
 
 import dask
@@ -212,7 +213,7 @@ def compute_hindcast(
     # think in real time dimension: real time = init + lag
     forecast = forecast.rename({'init': 'time'})
 
-    # If dask, then chunk in time.
+    # If dask, then only one chunk in time.
     if dask.is_dask_collection(forecast):
         forecast = forecast.chunk({'time': -1})
     if dask.is_dask_collection(verif):
@@ -234,6 +235,11 @@ def compute_hindcast(
         a['time'] = shift_cftime_index(a, 'time', n, freq)
         # Take real time verification data using real time forecast dates.
         b = verif.sel(time=a.time.values)
+
+        logging.info(
+            f'at lead={i}: dim={dim}: {a.time.min().dt.year.values}-'
+            f'{a.time.max().dt.year.values}'
+        )
 
         # adapt weights to shorter time
         if 'weights' in metric_kwargs:

--- a/climpred/tests/conftest.py
+++ b/climpred/tests/conftest.py
@@ -107,6 +107,7 @@ def perfectModelEnsemble_initialized_control(PM_ds_initialized_1d, PM_ds_control
 def hind_ds_initialized_1d():
     """CESM-DPLE initialized hindcast timeseries mean removed xr.Dataset."""
     da = load_dataset('CESM-DP-SST')
+    da['init'] = da.init.astype('int')
     return da - da.mean('init')
 
 

--- a/climpred/tests/test_effective_p_value.py
+++ b/climpred/tests/test_effective_p_value.py
@@ -12,7 +12,10 @@ def test_eff_sample_size_smaller_than_n_hind_da_initialized_1d(
     of the data."""
     N = hind_da_initialized_1d.mean('member').count('init')
     eff_N = compute_hindcast(
-        hind_da_initialized_1d, reconstruction_da_1d, metric='eff_n', common='max_dof',
+        hind_da_initialized_1d,
+        reconstruction_da_1d,
+        metric='eff_n',
+        alignment='maximize',
     )
     assert (eff_N <= N).all()
 
@@ -45,14 +48,14 @@ def test_eff_pearson_p_greater_or_equal_to_normal_p_hind_da_initialized_1d(
         hind_da_initialized_1d,
         reconstruction_da_1d,
         metric='pearson_r_p_value',
-        common='max_dof',
+        alignment='maximize',
         comparison=comparison,
     )
     eff_p = compute_hindcast(
         hind_da_initialized_1d,
         reconstruction_da_1d,
         metric='pearson_r_eff_p_value',
-        common='max_dof',
+        alignment='maximize',
         comparison=comparison,
     )
     assert (normal_p <= eff_p).all()
@@ -89,14 +92,14 @@ def test_eff_spearman_p_greater_or_equal_to_normal_p_hind_da_initialized_1d(
         hind_da_initialized_1d,
         reconstruction_da_1d,
         metric='spearman_r_p_value',
-        common='max_dof',
+        alignment='maximize',
         comparison=comparison,
     )
     eff_p = compute_hindcast(
         hind_da_initialized_1d,
         reconstruction_da_1d,
         metric='spearman_r_eff_p_value',
-        common='max_dof',
+        alignment='maximize',
         comparison=comparison,
     )
     assert (normal_p <= eff_p).all()

--- a/climpred/tests/test_effective_p_value.py
+++ b/climpred/tests/test_effective_p_value.py
@@ -12,7 +12,7 @@ def test_eff_sample_size_smaller_than_n_hind_da_initialized_1d(
     of the data."""
     N = hind_da_initialized_1d.mean('member').count('init')
     eff_N = compute_hindcast(
-        hind_da_initialized_1d, reconstruction_da_1d, metric='eff_n', max_dof=True,
+        hind_da_initialized_1d, reconstruction_da_1d, metric='eff_n', common='max_dof',
     )
     assert (eff_N <= N).all()
 
@@ -45,14 +45,14 @@ def test_eff_pearson_p_greater_or_equal_to_normal_p_hind_da_initialized_1d(
         hind_da_initialized_1d,
         reconstruction_da_1d,
         metric='pearson_r_p_value',
-        max_dof=True,
+        common='max_dof',
         comparison=comparison,
     )
     eff_p = compute_hindcast(
         hind_da_initialized_1d,
         reconstruction_da_1d,
         metric='pearson_r_eff_p_value',
-        max_dof=True,
+        common='max_dof',
         comparison=comparison,
     )
     assert (normal_p <= eff_p).all()
@@ -89,14 +89,14 @@ def test_eff_spearman_p_greater_or_equal_to_normal_p_hind_da_initialized_1d(
         hind_da_initialized_1d,
         reconstruction_da_1d,
         metric='spearman_r_p_value',
-        max_dof=True,
+        common='max_dof',
         comparison=comparison,
     )
     eff_p = compute_hindcast(
         hind_da_initialized_1d,
         reconstruction_da_1d,
         metric='spearman_r_eff_p_value',
-        max_dof=True,
+        common='max_dof',
         comparison=comparison,
     )
     assert (normal_p <= eff_p).all()

--- a/climpred/tests/test_hindcastEnsemble_class.py
+++ b/climpred/tests/test_hindcastEnsemble_class.py
@@ -85,7 +85,7 @@ def test_compute_metric(
     # compute over single observation
     hindcast.compute_metric('reconstruction')
     # test all keywords
-    hindcast.compute_metric(max_dof=True, metric='rmse', comparison='m2o')
+    hindcast.compute_metric(common='max_dof', metric='rmse', comparison='m2o')
 
 
 def test_compute_metric_single(hind_ds_initialized_1d, reconstruction_ds_1d):
@@ -116,7 +116,7 @@ def test_verify(hind_ds_initialized_1d, reconstruction_ds_1d, observations_ds_1d
     hindcast.verify()  # compute over all observations
     hindcast.verify('reconstruction')  # compute over single observation
     # test all keywords
-    hindcast.verify(max_dof=True, metric='rmse', comparison='m2o')
+    hindcast.verify(common='max_dof', metric='rmse', comparison='m2o')
 
 
 def test_verify_single(hind_ds_initialized_1d, reconstruction_ds_1d):

--- a/climpred/tests/test_hindcastEnsemble_class.py
+++ b/climpred/tests/test_hindcastEnsemble_class.py
@@ -85,7 +85,7 @@ def test_compute_metric(
     # compute over single observation
     hindcast.compute_metric('reconstruction')
     # test all keywords
-    hindcast.compute_metric(common='max_dof', metric='rmse', comparison='m2o')
+    hindcast.compute_metric(alignment='maximize', metric='rmse', comparison='m2o')
 
 
 def test_compute_metric_single(hind_ds_initialized_1d, reconstruction_ds_1d):
@@ -116,7 +116,7 @@ def test_verify(hind_ds_initialized_1d, reconstruction_ds_1d, observations_ds_1d
     hindcast.verify()  # compute over all observations
     hindcast.verify('reconstruction')  # compute over single observation
     # test all keywords
-    hindcast.verify(common='max_dof', metric='rmse', comparison='m2o')
+    hindcast.verify(alignment='maximize', metric='rmse', comparison='m2o')
 
 
 def test_verify_single(hind_ds_initialized_1d, reconstruction_ds_1d):

--- a/climpred/tests/test_lead_time_resolutions.py
+++ b/climpred/tests/test_lead_time_resolutions.py
@@ -122,6 +122,7 @@ def test_seasonal_resolution_perfect_model(monthly_initialized, monthly_obs):
 def test_yearly_resolution_hindcast(monthly_initialized, monthly_obs):
     """Tests that yearly resolution hindcast predictions work."""
     yearly_hindcast = monthly_initialized.resample(init='YS').mean()
+    print(yearly_hindcast.init.values)
     yearly_obs = monthly_obs.resample(time='YS').mean()
     yearly_hindcast.lead.attrs['units'] = 'years'
     assert compute_hindcast(yearly_hindcast, yearly_obs).all()

--- a/climpred/tests/test_lead_time_resolutions.py
+++ b/climpred/tests/test_lead_time_resolutions.py
@@ -122,7 +122,6 @@ def test_seasonal_resolution_perfect_model(monthly_initialized, monthly_obs):
 def test_yearly_resolution_hindcast(monthly_initialized, monthly_obs):
     """Tests that yearly resolution hindcast predictions work."""
     yearly_hindcast = monthly_initialized.resample(init='YS').mean()
-    print(yearly_hindcast.init.values)
     yearly_obs = monthly_obs.resample(time='YS').mean()
     yearly_hindcast.lead.attrs['units'] = 'years'
     assert compute_hindcast(yearly_hindcast, yearly_obs).all()

--- a/climpred/tests/test_logging_hindcast.py
+++ b/climpred/tests/test_logging_hindcast.py
@@ -1,0 +1,22 @@
+import logging
+
+from climpred.prediction import compute_hindcast
+
+
+def test_logg_compute_hindcast(
+    hind_ds_initialized_1d, reconstruction_ds_1d, caplog,
+):
+    """
+    Checks that logging in compute hindcast works.
+    """
+    with caplog.at_level(logging.INFO):
+        compute_hindcast(hind_ds_initialized_1d, reconstruction_ds_1d)
+        # check for each record
+        for i, record in enumerate(caplog.record_tuples):
+            print(record)
+            lead = hind_ds_initialized_1d.isel(lead=i).lead.values.astype('int')
+            assert f'at lead={lead}' in record[2]
+            # should change to cftime
+            # for now just checking years
+            first_real_time = hind_ds_initialized_1d.init.min().values + lead
+            assert f'{first_real_time}' in record[2]

--- a/climpred/tests/test_logging_hindcast.py
+++ b/climpred/tests/test_logging_hindcast.py
@@ -1,13 +1,12 @@
 import logging
 
+import pytest
 import xarray as xr
 
 from climpred.prediction import compute_hindcast
 
 
-def test_logg_compute_hindcast(
-    hind_ds_initialized_1d, reconstruction_ds_1d, caplog,
-):
+def test_logg_compute_hindcast(hind_ds_initialized_1d, reconstruction_ds_1d, caplog):
     """
     Checks that logging in compute hindcast works.
     """
@@ -32,7 +31,69 @@ def test_logg_compute_hindcast(
             lead = hind_ds_initialized_1d.isel(lead=i).lead.values.astype('int')
             assert f'at lead={str(lead).zfill(2)}' in record[2]
             # for now just checking years
-            first_real_time_year = (
+            first_year_per_lead = (
                 hind_ds_initialized_1d.init.min().dt.year.values + lead
             )
-            assert f'{first_real_time_year}' in record[2]
+            assert f'{first_year_per_lead}' in record[2]
+
+
+@pytest.mark.parametrize('common', ['init', 'verif', 'max_dof', None])
+def test_logg_compute_hindcast_common(
+    hind_ds_initialized_1d, reconstruction_ds_1d, caplog, common
+):
+    """
+    Checks that logging in compute hindcast works.
+    """
+    # setting up data for cftime init/time
+    hind_ds_initialized_1d['init'] = xr.cftime_range(
+        start=str(hind_ds_initialized_1d.init.min().values),
+        freq='YS',
+        periods=hind_ds_initialized_1d.init.size,
+    )
+    hind_ds_initialized_1d.lead.attrs['units'] = 'years'
+    reconstruction_ds_1d['time'] = xr.cftime_range(
+        start=str(reconstruction_ds_1d.time.min().values),
+        freq='YS',
+        periods=reconstruction_ds_1d.time.size,
+    )
+
+    with caplog.at_level(logging.INFO):
+        compute_hindcast(hind_ds_initialized_1d, reconstruction_ds_1d)
+        # check for each record
+        for i, record in enumerate(caplog.record_tuples):
+            print(record)
+            lead = hind_ds_initialized_1d.isel(lead=i).lead.values.astype('int')
+            assert f'at lead={str(lead).zfill(2)}' in record[2]
+            if common in [None, 'max_dof']:
+                # check that
+                first_year_per_lead = (
+                    hind_ds_initialized_1d.init.min().dt.year.values + lead
+                )
+                assert f'{first_year_per_lead}' in record[2]
+            elif common == 'verif':
+                # check that verification time is always the same
+                # const_verif_length = xx
+                pass  # skip test for now
+                # get verification times
+                # first = 1980  # made up
+                # last = 2000  # made up
+                # assert f'{first}' in record[2] and f'{last}' in record[2]
+                # check always same time length verified
+                # assert const_verif_length == last_year_per_lead - first_year_per_lead
+            elif common == 'init':
+                # check that verification length is always the same and init stay the
+                # same, therefore verification time should monotonically decrease for
+                # monotonic lead increases
+                # const_verif_length = xx
+                first_year_per_lead = (
+                    hind_ds_initialized_1d.init.min().dt.year.values + lead
+                )
+                assert f'{first_year_per_lead}' in record[2]
+                last_year_per_lead = (
+                    hind_ds_initialized_1d.init.max().dt.year.values
+                    + lead
+                    - hind_ds_initialized_1d.lead.size
+                )
+                assert f'{last_year_per_lead}' in record[2]
+                # check always same time length verified
+                # assert const_verif_length == last_year_per_lead - first_year_per_lead

--- a/climpred/tests/test_logging_hindcast.py
+++ b/climpred/tests/test_logging_hindcast.py
@@ -1,5 +1,7 @@
 import logging
 
+import xarray as xr
+
 from climpred.prediction import compute_hindcast
 
 
@@ -9,14 +11,28 @@ def test_logg_compute_hindcast(
     """
     Checks that logging in compute hindcast works.
     """
+    # setting up data for cftime init/time
+    hind_ds_initialized_1d['init'] = xr.cftime_range(
+        start=str(hind_ds_initialized_1d.init.min().values),
+        freq='YS',
+        periods=hind_ds_initialized_1d.init.size,
+    )
+    hind_ds_initialized_1d.lead.attrs['units'] = 'years'
+    reconstruction_ds_1d['time'] = xr.cftime_range(
+        start=str(reconstruction_ds_1d.time.min().values),
+        freq='YS',
+        periods=reconstruction_ds_1d.time.size,
+    )
+
     with caplog.at_level(logging.INFO):
         compute_hindcast(hind_ds_initialized_1d, reconstruction_ds_1d)
         # check for each record
         for i, record in enumerate(caplog.record_tuples):
             print(record)
             lead = hind_ds_initialized_1d.isel(lead=i).lead.values.astype('int')
-            assert f'at lead={lead}' in record[2]
-            # should change to cftime
+            assert f'at lead={str(lead).zfill(2)}' in record[2]
             # for now just checking years
-            first_real_time = hind_ds_initialized_1d.init.min().values + lead
-            assert f'{first_real_time}' in record[2]
+            first_real_time_year = (
+                hind_ds_initialized_1d.init.min().dt.year.values + lead
+            )
+            assert f'{first_real_time_year}' in record[2]

--- a/climpred/tests/test_logging_hindcast.py
+++ b/climpred/tests/test_logging_hindcast.py
@@ -37,12 +37,13 @@ def test_logg_compute_hindcast(hind_ds_initialized_1d, reconstruction_ds_1d, cap
             assert f'{first_year_per_lead}' in record[2]
 
 
-@pytest.mark.parametrize('common', ['init', 'verif', 'max_dof', None])
-def test_logg_compute_hindcast_common(
-    hind_ds_initialized_1d, reconstruction_ds_1d, caplog, common
+@pytest.mark.parametrize('alignment', ['init', 'verif', 'maximize', None])
+def test_logg_compute_hindcast_alignment(
+    hind_ds_initialized_1d, reconstruction_ds_1d, caplog, alignment
 ):
     """
-    Checks that logging in compute hindcast works.
+    Checks that logging in compute hindcast captures the correct verification-time
+    matching based on `alignment`.
     """
     # setting up data for cftime init/time
     hind_ds_initialized_1d['init'] = xr.cftime_range(
@@ -64,13 +65,13 @@ def test_logg_compute_hindcast_common(
             print(record)
             lead = hind_ds_initialized_1d.isel(lead=i).lead.values.astype('int')
             assert f'at lead={str(lead).zfill(2)}' in record[2]
-            if common in [None, 'max_dof']:
+            if alignment == 'maximize':
                 # check that
                 first_year_per_lead = (
                     hind_ds_initialized_1d.init.min().dt.year.values + lead
                 )
                 assert f'{first_year_per_lead}' in record[2]
-            elif common == 'verif':
+            elif alignment == 'verif':
                 # check that verification time is always the same
                 # const_verif_length = xx
                 pass  # skip test for now
@@ -80,7 +81,79 @@ def test_logg_compute_hindcast_common(
                 # assert f'{first}' in record[2] and f'{last}' in record[2]
                 # check always same time length verified
                 # assert const_verif_length == last_year_per_lead - first_year_per_lead
-            elif common == 'init':
+            elif alignment == 'init':
+                # check that verification length is always the same and init stay the
+                # same, therefore verification time should monotonically decrease for
+                # monotonic lead increases
+                # const_verif_length = xx
+                first_year_per_lead = (
+                    hind_ds_initialized_1d.init.min().dt.year.values + lead
+                )
+                assert f'{first_year_per_lead}' in record[2]
+                last_year_per_lead = (
+                    hind_ds_initialized_1d.init.max().dt.year.values
+                    + lead
+                    - hind_ds_initialized_1d.lead.size
+                )
+                assert f'{last_year_per_lead}' in record[2]
+                # check always same time length verified
+                # assert const_verif_length == last_year_per_lead - first_year_per_lead
+
+
+@pytest.mark.parametrize('alignment', ['init', 'verif', 'maximize'])
+def test_logg_compute_hindcast_alignment_checking_actual_years(
+    hind_ds_initialized_1d, reconstruction_ds_1d, caplog, alignment
+):
+    """
+    Checks that logging in compute hindcast works where we check on actual hard coded
+    numbers based on pre-defined datasets from `load_dataset`:
+
+    data:
+    - hind: hind_ds_initialized_1d: inits: 1955-2017, leads: 1-10
+    - verif: reconstruction_ds_1d: time: 1954-2015
+
+    expected verification time logged for keyword `alignment`: and pattern:
+    - inits: 1956-2006, 1957-2007, ... , 1965-2015 : first_common_init_verif+lead -
+    - verif: 1965-2006 : max(first_init+max_lead, verif_time)-min(last_init-max_lead)
+    - maximize: 1956-2015, 1957-2015, ... , 1965-2015: maximizing
+    """
+    # setting up data for cftime init/time
+    hind_ds_initialized_1d['init'] = xr.cftime_range(
+        start=str(hind_ds_initialized_1d.init.min().values),
+        freq='YS',
+        periods=hind_ds_initialized_1d.init.size,
+    )
+    hind_ds_initialized_1d.lead.attrs['units'] = 'years'
+    reconstruction_ds_1d['time'] = xr.cftime_range(
+        start=str(reconstruction_ds_1d.time.min().values),
+        freq='YS',
+        periods=reconstruction_ds_1d.time.size,
+    )
+
+    with caplog.at_level(logging.INFO):
+        compute_hindcast(hind_ds_initialized_1d, reconstruction_ds_1d)
+        # check for each record
+        for i, record in enumerate(caplog.record_tuples):
+            print(record)
+            lead = hind_ds_initialized_1d.isel(lead=i).lead.values.astype('int')
+            assert f'at lead={str(lead).zfill(2)}' in record[2]
+            if alignment == 'maximize':
+                # check that
+                first_year_per_lead = (
+                    hind_ds_initialized_1d.init.min().dt.year.values + lead
+                )
+                assert f'{first_year_per_lead}' in record[2]
+            elif alignment == 'verif':
+                # check that verification time is always the same
+                # const_verif_length = xx
+                pass  # skip test for now
+                # get verification times
+                # first = 1980  # made up
+                # last = 2000  # made up
+                # assert f'{first}' in record[2] and f'{last}' in record[2]
+                # check always same time length verified
+                # assert const_verif_length == last_year_per_lead - first_year_per_lead
+            elif alignment == 'init':
                 # check that verification length is always the same and init stay the
                 # same, therefore verification time should monotonically decrease for
                 # monotonic lead increases

--- a/climpred/tests/test_logging_hindcast.py
+++ b/climpred/tests/test_logging_hindcast.py
@@ -37,7 +37,7 @@ def test_logg_compute_hindcast(hind_ds_initialized_1d, reconstruction_ds_1d, cap
             assert f'{first_year_per_lead}' in record[2]
 
 
-@pytest.mark.parametrize('alignment', ['init', 'verif', 'maximize', None])
+@pytest.mark.parametrize('alignment', ['init', 'same_verif', 'maximize'])
 def test_logg_compute_hindcast_alignment(
     hind_ds_initialized_1d, reconstruction_ds_1d, caplog, alignment
 ):
@@ -71,7 +71,7 @@ def test_logg_compute_hindcast_alignment(
                     hind_ds_initialized_1d.init.min().dt.year.values + lead
                 )
                 assert f'{first_year_per_lead}' in record[2]
-            elif alignment == 'verif':
+            elif alignment == 'same_verif':
                 # check that verification time is always the same
                 # const_verif_length = xx
                 pass  # skip test for now
@@ -100,7 +100,7 @@ def test_logg_compute_hindcast_alignment(
                 # assert const_verif_length == last_year_per_lead - first_year_per_lead
 
 
-@pytest.mark.parametrize('alignment', ['init', 'verif', 'maximize'])
+@pytest.mark.parametrize('alignment', ['init', 'same_verif', 'maximize'])
 def test_logg_compute_hindcast_alignment_checking_actual_years(
     hind_ds_initialized_1d, reconstruction_ds_1d, caplog, alignment
 ):
@@ -143,7 +143,7 @@ def test_logg_compute_hindcast_alignment_checking_actual_years(
                     hind_ds_initialized_1d.init.min().dt.year.values + lead
                 )
                 assert f'{first_year_per_lead}' in record[2]
-            elif alignment == 'verif':
+            elif alignment == 'same_verif':
                 # check that verification time is always the same
                 # const_verif_length = xx
                 pass  # skip test for now


### PR DESCRIPTION
# Description

 - logging to check which times are verified at each lead
- for now only checks years. otherwise use xr.cftime.shift
- implement common to `compute_hindcast`:
    - missing: `verif`
    - add logging examples to verification docs

resources
----------

- https://docs.pytest.org/en/latest/logging.html
- https://realpython.com/python-logging/

Use #318 

## Type of change

Please delete options that are not relevant.

-   [ ]  Bug fix (non-breaking change which fixes an issue)
-   [x]  New feature (non-breaking change which adds functionality)
-   [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ]  This change requires a documentation update
-   [ ]  Performance (if you touched existing code run `asv` to detect performance changes)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here.

## Checklist (while developing)

-   [ ]  I have added docstrings to all new functions.
-   [ ]  I have commented my code, particularly in hard-to-understand areas
-   [ ]  Tests added for `pytest`, if necessary.
-   [ ]  I have updated the sphinx documentation, if necessary.

## Pre-Merge Checklist (final steps)

-   [ ]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

## References

Please add any references to manuscripts, textbooks, etc.
