### PR TITLE
Remove coveralls token

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-repo_token: M6KWeBXmDYgetbGH1OMSF5fUj85tRIegc

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - python setup.py install --user
 
 script:
-  - coverage run --source climpred setup.py test 
+  - coverage run --source climpred setup.py py.test 
   - coverage report
   - pushd docs
   - nbstripout source/*.ipynb source/examples/decadal/*.ipynb source/examples/subseasonal/*.ipynb

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - python setup.py install --user
 
 script:
-  - coverage run --source climpred setup.py py.test 
+  - coverage run --source climpred setup.py -m py.test 
   - coverage report
   - pushd docs
   - nbstripout source/*.ipynb source/examples/decadal/*.ipynb source/examples/subseasonal/*.ipynb

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - python setup.py install --user
 
 script:
-  - coverage run --source climpred setup.py -m py.test 
+  - coverage run --source climpred -m py.test 
   - coverage report
   - pushd docs
   - nbstripout source/*.ipynb source/examples/decadal/*.ipynb source/examples/subseasonal/*.ipynb

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,6 @@ install:
   - which python
   - pip install .
   - python setup.py install --user
-  - pip install pytest-cov
-  - pip install coveralls
-  - pip install black
-  - pip install flake8
-  - pip install isort
 
 script:
   - coverage run --source climpred -m py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - python setup.py install --user
 
 script:
-  - coverage run --source climpred -m py.test
+  - coverage run --source climpred setup.py test 
   - coverage report
   - pushd docs
   - nbstripout source/*.ipynb source/examples/decadal/*.ipynb source/examples/subseasonal/*.ipynb


### PR DESCRIPTION
# Description

Removes the `coveralls.yml` file with our token, since that's not supposed to be public (https://stackoverflow.com/questions/39501417/how-can-i-connect-coveralls-and-travis-in-github). Travis should be able to handle connecting to coveralls, since we're a public repo.