### PR TITLE
Enforce most recent cftime version

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -18,6 +18,6 @@ This should explain **why** the current behaviour is a problem and why the expec
 #### Output of `climpred.show_versions()`
 
 <details>
-# Paste the output here xr.show_versions() here
+# Paste the output here climpred.show_versions() here
 
 </details>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -75,7 +75,8 @@ Internals/Minor Fixes
   size-based metrics. (:pr: `353`) `Riley X. Brady`_.
 - Faster bootstrapping without replacement used in threshold functions of
   climpred.stats (:pr:`354`) `Aaron Spring`_.
-
+- Require ``cftime v1.1.2``, which modifies their object handling to create 200-400x
+  speedups in some basic operations. (:pr:`356`) `Riley X. Brady`_.
 
 
 Documentation

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -16,7 +16,6 @@ dependencies:
   # Input/Output
   - netcdf4
   # Miscellaneous
-  - cftime>=1.1.2 # Optimization changes to make cftime fast.
   - lxml
   - tqdm
   # Numerics
@@ -59,6 +58,7 @@ dependencies:
   - nc-time-axis
   - pip
   - pip:
+      - cftime>=1.1.2 # Optimization changes to make cftime fast.
       - pytest-tldr
       - pytest-lazy-fixture
       - git+https://github.com/bradyrx/esmtools

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -16,6 +16,7 @@ dependencies:
   # Input/Output
   - netcdf4
   # Miscellaneous
+  - cftime>=1.1.2 # Optimization changes to make cftime fast.
   - lxml
   - tqdm
   # Numerics

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cftime>=1.1.2
 eofs
 matplotlib
 numpy


### PR DESCRIPTION
# Description

This enforces `cftime` version `1.1.2` which was released yesterday and optimizes `cftime` objects, getting 200-400x speedups on some of their basic functions. This will work in hand with our bootstrap optimizations to make `climpred` faster. This will speed up the base operations, while our bootstrap changes will make `dask` easier to handle.

See my issue at `cftime` on speedups: https://github.com/Unidata/cftime/issues/158.

## Type of change

Please delete options that are not relevant.

-   [X]  Performance (if you touched existing code run `asv` to detect performance changes)
-   [X]  refactoring

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. This could point to a cell in the updated notebooks. Or a snippet of code with accompanying figures here.