### PR TITLE
Add missing coords to PredictionEnsemble objects

### DIFF
--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -31,7 +31,7 @@ from .smoothing import (
     spatial_smoothing_xrcoarsen,
     temporal_smoothing,
 )
-from .utils import add_missing_coords, convert_time_index
+from .utils import add_coords_from_other_ds, add_missing_coords, convert_time_index
 
 
 def _display_metadata(self):
@@ -142,7 +142,7 @@ class PredictionEnsemble:
         has_valid_lead_units(xobj)
         # Add coordinates to any spatial dims that don't have them. This helps avoid
         # xarray errors during computation.
-        xobj = add_missing_coords(xobj, except_dims=('init', 'lead', 'memmber'))
+        add_missing_coords(xobj, exclude_dims=('init', 'lead', 'memmber'))
         # Add initialized dictionary and reserve sub-dictionary for an uninitialized
         # run.
         self._datasets = {'initialized': xobj, 'uninitialized': {}}
@@ -532,6 +532,11 @@ class PerfectModelEnsemble(PredictionEnsemble):
         # Check that init is int, cftime, or datetime; convert ints or cftime to
         # datetime.
         xobj = convert_time_index(xobj, 'time', 'xobj[init]')
+        # Adds coords to xobj from initialized dataset if missing. This helps avoid
+        # errors in xarray computation.
+        add_coords_from_other_ds(
+            xobj, self._datasets['initialized'], exclude_dims=['time']
+        )
         datasets = self._datasets.copy()
         datasets.update({'control': xobj})
         return self._construct_direct(datasets, kind='perfect')
@@ -824,6 +829,11 @@ class HindcastEnsemble(PredictionEnsemble):
         # Check that time is int, cftime, or datetime; convert ints or cftime to
         # datetime.
         xobj = convert_time_index(xobj, 'time', 'xobj[init]')
+        # Adds coords to xobj from initialized dataset if missing. This helps avoid
+        # errors in xarray computation.
+        add_coords_from_other_ds(
+            xobj, self._datasets['initialized'], exclude_dims=['time']
+        )
         # For some reason, I could only get the non-inplace method to work
         # by updating the nested dictionaries separately.
         datasets_obs = self._datasets['observations'].copy()
@@ -847,6 +857,11 @@ class HindcastEnsemble(PredictionEnsemble):
         # Check that init is int, cftime, or datetime; convert ints or cftime to
         # datetime.
         xobj = convert_time_index(xobj, 'time', 'xobj[init]')
+        # Adds coords to xobj from initialized dataset if missing. This helps avoid
+        # errors in xarray computation.
+        add_coords_from_other_ds(
+            xobj, self._datasets['initialized'], exclude_dims=['time']
+        )
         datasets = self._datasets.copy()
         datasets.update({'uninitialized': xobj})
         return self._construct_direct(datasets, kind='hindcast')

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -31,7 +31,7 @@ from .smoothing import (
     spatial_smoothing_xrcoarsen,
     temporal_smoothing,
 )
-from .utils import convert_time_index
+from .utils import add_missing_coords, convert_time_index
 
 
 def _display_metadata(self):
@@ -140,6 +140,9 @@ class PredictionEnsemble:
         # Put this after `convert_time_index` since it assigns 'years' attribute if the
         # `init` dimension is a `float` or `int`.
         has_valid_lead_units(xobj)
+        # Add coordinates to any spatial dims that don't have them. This helps avoid
+        # xarray errors during computation.
+        xobj = add_missing_coords(xobj, except_dims=('init', 'lead', 'memmber'))
         # Add initialized dictionary and reserve sub-dictionary for an uninitialized
         # run.
         self._datasets = {'initialized': xobj, 'uninitialized': {}}

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -15,6 +15,33 @@ from .constants import FREQ_LIST_TO_INFER_STRIDE, HINDCAST_CALENDAR_STR
 from .metrics import METRIC_ALIASES
 
 
+def add_missing_coords(ds, except_dims=None):
+    """Adds index coordinates to specified dims that are missing coordinates.
+
+    Args:
+        ds (xarray object): Dataset to add coordinates to.
+        except_dims (tuple or list): Dimensions to ignore. I.e., add coordinates to
+            any dims that exist outside this list and are missing coordinates.
+
+    Returns;
+        ds (xarray object): Original ``xr.Dataset`` or ``xr.DataArray`` with new
+            coords appended to it.
+    """
+    assert type(except_dims) in [
+        list,
+        tuple,
+    ], 'except_dims must be of type list or tuple.'
+    if except_dims is None:
+        check_dims = [dim for dim in ds.dims]
+    else:
+        check_dims = [dim for dim in ds.dims if dim not in except_dims]
+
+    for dim in check_dims:
+        if dim not in ds.coords:
+            ds.coords[dim] = np.arange(ds[dim].size)
+    return ds
+
+
 def assign_attrs(
     skill,
     ds,

--- a/climpred/utils.py
+++ b/climpred/utils.py
@@ -15,31 +15,58 @@ from .constants import FREQ_LIST_TO_INFER_STRIDE, HINDCAST_CALENDAR_STR
 from .metrics import METRIC_ALIASES
 
 
-def add_missing_coords(ds, except_dims=None):
+def add_coords_from_other_ds(ds_add_to, ds_add_from, exclude_dims=None):
+    """Adds missing coordinates on one xarray object from the coordinates for the same
+    dim on another xarray object.
+
+    Args:
+        ds_add_to (xarray object): xr.Dataset or xr.DataArray to add coords to.
+        ds_add_from (xarray object): xr.Dataset or xr.DataArray to get coordinate
+            labels from.
+        exclude-dims (tuple or list, optional): Dimensions to ignore. I.e., add
+            coordinates to any dims that exist outside this list and are missing
+            coordinates.
+    """
+    assert type(exclude_dims) in [
+        None,
+        list,
+        tuple,
+    ], 'exclude_dims must be of type list or tuple.'
+    if exclude_dims is None:
+        check_dims = [dim for dim in ds_add_to.dims]
+    else:
+        check_dims = [dim for dim in ds_add_to.dims if dim not in exclude_dims]
+    for dim in check_dims:
+        if dim not in ds_add_to.coords:
+            ds_add_to.coords[dim] = ds_add_from.coords[dim]
+
+
+def add_missing_coords(ds, exclude_dims=None):
     """Adds index coordinates to specified dims that are missing coordinates.
 
     Args:
         ds (xarray object): Dataset to add coordinates to.
-        except_dims (tuple or list): Dimensions to ignore. I.e., add coordinates to
-            any dims that exist outside this list and are missing coordinates.
+        exclude_dims (tuple or list, optional): Dimensions to ignore. I.e., add
+            coordinates to any dims that exist outside this list and are missing
+            coordinates.
 
     Returns;
         ds (xarray object): Original ``xr.Dataset`` or ``xr.DataArray`` with new
             coords appended to it.
     """
-    assert type(except_dims) in [
+    assert type(exclude_dims) in [
+        None,
         list,
         tuple,
-    ], 'except_dims must be of type list or tuple.'
-    if except_dims is None:
+    ], 'exclude_dims must be of type list or tuple.'
+    if exclude_dims is None:
         check_dims = [dim for dim in ds.dims]
     else:
-        check_dims = [dim for dim in ds.dims if dim not in except_dims]
+        check_dims = [dim for dim in ds.dims if dim not in exclude_dims]
 
     for dim in check_dims:
         if dim not in ds.coords:
             ds.coords[dim] = np.arange(ds[dim].size)
-    return ds
 
 
 def assign_attrs(


### PR DESCRIPTION
# Description

Automatically appends coords that are missing when adding e.g. observations to a `HindcastEnsemble`. This helps to avoid errors in `xarray` when running compute functions.

Closes https://github.com/bradyrx/climpred/issues/314

## Type of change

Please delete options that are not relevant.

-   [x]  New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Still need to add tests. Currently testing in a notebook.

## Checklist (while developing)

-   [X]  I have added docstrings to all new functions.
-   [X]  I have commented my code, particularly in hard-to-understand areas
-   [ ]  Tests added for `pytest`, if necessary.

## Pre-Merge Checklist (final steps)

-   [ ]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [ ]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

## Notes

Currently getting the error

```python-traceback
ValueError: zero-size array to reduction operation minimum which has no identity
```

This is when running `.verify()` after simply having coordinates copied over for missing coordinate dimensions. Not sure what's going on yet.

```python
from climpred import HindcastEnsemble
import xarray as xr
import numpy as np

x = [0, 5, 10]
y = [-30, -25, -20]
lead = np.arange(10) + 1

nx = len(x)
ny = len(y)
nlead = len(lead)
ninit = 5
ntime = 6

init = xr.cftime_range('1990', freq='YS', periods=ninit)
time = xr.cftime_range('1990', freq='YS', periods=ntime)

hind = xr.DataArray(np.random.rand(ninit, nlead, nx, ny),
                    dims=['init', 'lead', 'x', 'y'],
                    coords=[init, lead, x, y]).rename('SST')
hind['lead'].attrs['units'] = 'years'
obs = xr.DataArray(np.random.rand(ntime, nx, ny),
                   dims=['time', 'x', 'y'],
                   coords=[time, x, y]).rename('SST')
del obs['x'], obs['y']
del hind['x']

he = HindcastEnsemble(hind)
he = he.add_observations(obs, 'obs')
he.verify(alignment='maximize')
```

