### PR TITLE
add metric_kwargs to PredictionEnsemble methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 What's New
 ==========
 
-climpred v2.1.0 (2020-06-08)
+climpred v2.x.x (2020-06-xx)
 ============================
 
 New Features
@@ -10,6 +10,15 @@ New Features
 
 - Use math operations like ``+-*/`` with py:class:`~climpred.classes.HindcastEnsemble`
   and :py:class:`~climpred.classes.PerfectModelEnsemble`. (:pr:`377`) `Aaron Spring`_.
+
+Bug Fixes
+---------
+
+- ``PredictionEnsemble.verify()``, ``PerfectModelEnsemble.compute_uninitialized()`` and
+  ``PerfectModelEnsemble.bootstrap()`` now accept ``metric_kwargs``. (:pr:`387`)
+  `Aaron Spring`_.
+- ``HindcastEnsemble.verify()`` now accepts ``metric_kwargs``. (:pr:`387`)
+  `Aaron Spring`_.
 
 Documentation
 -------------
@@ -19,12 +28,9 @@ Documentation
 
 Internals/Minor Fixes
 ---------------------
-- ``PerfectModelEnsemble.verify()`` replaces depreciated
+- ``PerfectModelEnsemble.verify()`` replaces deprecated
   ``PerfectModelEnsemble.compute_metric()`` and accepts ``reference`` as keyword.
   (:pr:`387`) `Aaron Spring`_.
-- ``PredictionEnsemble.verify()``, ``PerfectModelEnsemble.compute_uninitialized()`` and
-  ``PerfectModelEnsemble.bootstrap()`` now accepts ``metric_kwargs``. (:pr:`387`)
-  `Aaron Spring`_.
 
 
 climpred v2.1.0 (2020-06-08)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,8 @@ Documentation
 Internals/Minor Fixes
 ---------------------
 - ``PerfectModelEnsemble.verify()`` replaces depreciated
-  ``PerfectModelEnsemble.compute_metric()``. (:pr:`387`) `Aaron Spring`_.
+  ``PerfectModelEnsemble.compute_metric()`` and accepts ``reference`` as keyword.
+  (:pr:`387`) `Aaron Spring`_.
 - ``PredictionEnsemble.verify()``, ``PerfectModelEnsemble.compute_uninitialized()`` and
   ``PerfectModelEnsemble.bootstrap()`` now accepts ``metric_kwargs``. (:pr:`387`)
   `Aaron Spring`_.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,14 @@ Documentation
 - Adds section on how to use arithmetic with ``PredictionEnsemble`` objects.
   (:pr:`378`) `Riley X. Brady`_.
 
+Internals/Minor Fixes
+---------------------
+- ``PerfectModelEnsemble.verify()`` replaces depreciated
+  ``PerfectModelEnsemble.compute_metric()``. (:pr:`387`) `Aaron Spring`_.
+- ``PredictionEnsemble.verify()``, ``PerfectModelEnsemble.compute_uninitialized()`` and
+  ``PerfectModelEnsemble.bootstrap()`` now accepts ``metric_kwargs``. (:pr:`387`)
+  `Aaron Spring`_.
+
 
 climpred v2.1.0 (2020-06-08)
 ============================

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import xarray as xr
 from IPython.display import display_html
@@ -555,14 +557,15 @@ class PerfectModelEnsemble(PredictionEnsemble):
         """Returns the control as an xarray dataset."""
         return self._datasets['control']
 
-    def compute_metric(self, metric='pearson_r', comparison='m2m'):
+    def verify(self, metric='pearson_r', comparison='m2e', **metric_kwargs):
         """Compares the initialized ensemble to the control run.
 
         Args:
-            metric (str, default 'pearson_r'):
+            metric (str, default 'pearson_r' or Metric):
               Metric to apply in the comparison.
             comparison (str, default 'm2m'):
               How to compare the climate prediction ensemble to the control.
+            **metric_kwargs (optional): arguments passed to `metric`.
 
         Returns:
             Result of the comparison as a Dataset.
@@ -578,9 +581,16 @@ class PerfectModelEnsemble(PredictionEnsemble):
             input_dict=input_dict,
             metric=metric,
             comparison=comparison,
+            **metric_kwargs,
         )
 
-    def compute_uninitialized(self, metric='pearson_r', comparison='m2e'):
+    def compute_metric(self, metric='pearson_r', comparison='m2e', **metric_kwargs):
+        warnings.warn('compute_metric() is depreciated. Please use verify().')
+        return self.verify(metric=metric, comparison=comparison, **metric_kwargs)
+
+    def compute_uninitialized(
+        self, metric='pearson_r', comparison='m2e', **metric_kwargs
+    ):
         """Compares the bootstrapped uninitialized run to the control run.
 
         Args:
@@ -590,6 +600,7 @@ class PerfectModelEnsemble(PredictionEnsemble):
               How to compare to the control run.
             running (int, default None):
               Size of the running window for variance smoothing.
+            **metric_kwargs (optional): arguments passed to `metric`.
 
         Returns:
             Result of the comparison as a Dataset.
@@ -609,6 +620,7 @@ class PerfectModelEnsemble(PredictionEnsemble):
             input_dict=input_dict,
             metric=metric,
             comparison=comparison,
+            **metric_kwargs,
         )
 
     def compute_persistence(self, metric='pearson_r'):
@@ -650,6 +662,7 @@ class PerfectModelEnsemble(PredictionEnsemble):
         sig=95,
         iterations=500,
         pers_sig=None,
+        **metric_kwargs,
     ):
         """Bootstrap ensemble simulations with replacement.
 
@@ -665,6 +678,7 @@ class PerfectModelEnsemble(PredictionEnsemble):
                 bootstrapping with replacement.
             pers_sig (int, default None):
                 If not None, the separate significance level for persistence.
+            **metric_kwargs (optional): arguments passed to `metric`.
 
         Returns:
             Dictionary of Datasets for each variable applied to with the
@@ -703,6 +717,7 @@ class PerfectModelEnsemble(PredictionEnsemble):
             sig=sig,
             iterations=iterations,
             pers_sig=pers_sig,
+            **metric_kwargs,
         )
 
 
@@ -876,6 +891,7 @@ class HindcastEnsemble(PredictionEnsemble):
         comparison='e2o',
         alignment='same_verifs',
         dim='init',
+        **metric_kwargs,
     ):
         """Verifies the initialized ensemble against observations/verification data.
 
@@ -899,6 +915,7 @@ class HindcastEnsemble(PredictionEnsemble):
                 - same_verif: slice to a common/consistent verification time frame prior
                 to computing metric. This philosophy follows the thought that each lead
                 should be based on the same set of verification dates.
+            **metric_kwargs (optional): arguments passed to `metric`.
 
         Returns:
             Dataset of comparison results (if comparing to one observational product),
@@ -1005,4 +1022,5 @@ class HindcastEnsemble(PredictionEnsemble):
             dim=dim,
             hist=hist,
             reference=reference,
+            **metric_kwargs,
         )

--- a/climpred/classes.py
+++ b/climpred/classes.py
@@ -565,7 +565,7 @@ class PerfectModelEnsemble(PredictionEnsemble):
         Args:
             metric (str, default 'pearson_r' or Metric):
               Metric to apply in the comparison.
-            comparison (str, default 'm2m'):
+            comparison (str, default 'm2e'):
               How to compare the climate prediction ensemble to the control.
             reference (str, list of str): reference forecasts to compare against.
             **metric_kwargs (optional): arguments passed to `metric`.

--- a/climpred/tests/conftest.py
+++ b/climpred/tests/conftest.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from climpred import PerfectModelEnsemble
+from climpred import HindcastEnsemble, PerfectModelEnsemble
 from climpred.constants import HINDCAST_CALENDAR_STR, PM_CALENDAR_STR
 from climpred.tutorial import load_dataset
 from climpred.utils import convert_time_index
@@ -235,6 +235,20 @@ def observations_da_1d(observations_ds_1d):
     """Historical timeseries from observations matching `hind_da_initialized_1d` and
     `hind_da_uninitialized_1d` mean removed xr.DataArray."""
     return observations_ds_1d['SST']
+
+
+@pytest.fixture
+def hindcast_hist_obs_1d(
+    hind_ds_initialized_1d, hist_ds_uninitialized_1d, observations_ds_1d
+):
+    """HindcastEnsemble initialized with `initialized`, `uninitialzed` and `obs`."""
+    hindcast = HindcastEnsemble(hind_ds_initialized_1d)
+    hindcast = hindcast.add_uninitialized(hist_ds_uninitialized_1d)
+    hindcast = hindcast.add_observations(observations_ds_1d, 'obs')
+    hindcast = hindcast - hindcast.sel(time=slice('1964', '2014')).mean('time').sel(
+        init=slice('1964', '2014')
+    ).mean('init')
+    return hindcast
 
 
 @pytest.fixture

--- a/climpred/tests/test_hindcastEnsemble_class.py
+++ b/climpred/tests/test_hindcastEnsemble_class.py
@@ -172,3 +172,11 @@ def test_verify_metric_kwargs(hindcast_hist_obs_1d):
         threshold=0.5,
         reference='historical',
     )
+
+
+def test_verify_fails_expected_metric_kwargs(hindcast_hist_obs_1d):
+    """Test that HindcastEnsemble fails when metric_kwargs expected but not given."""
+    hindcast = hindcast_hist_obs_1d
+    with pytest.raises(ValueError) as excinfo:
+        hindcast.verify(metric='threshold_brier_score', comparison='m2o')
+    assert 'Please provide threshold.' == str(excinfo.value)

--- a/climpred/tests/test_hindcastEnsemble_class.py
+++ b/climpred/tests/test_hindcastEnsemble_class.py
@@ -4,14 +4,14 @@ from climpred import HindcastEnsemble
 
 
 def test_hindcastEnsemble_init(hind_ds_initialized_1d):
-    """Test to see hindcast ensemble can be initialized"""
+    """Test to see hindcast ensemble can be initialized with xr.Dataset."""
     hindcast = HindcastEnsemble(hind_ds_initialized_1d)
     print(hindcast)
     assert hindcast
 
 
 def test_hindcastEnsemble_init_da(hind_da_initialized_1d):
-    """Test to see hindcast ensemble can be initialized with da"""
+    """Test to see hindcast ensemble can be initialized with xr.DataArray."""
     hindcast = HindcastEnsemble(hind_da_initialized_1d)
     assert hindcast
 
@@ -162,3 +162,13 @@ def test_inplace(
     hindcast.sum('init')
     summed = hindcast.sum('init')
     assert hindcast != summed
+
+
+def test_verify_metric_kwargs(hindcast_hist_obs_1d):
+    """Test that HindcastEnsemble works with metrics using metric_kwargs."""
+    assert hindcast_hist_obs_1d.verify(
+        metric='threshold_brier_score',
+        comparison='m2o',
+        threshold=0.5,
+        reference='historical',
+    )

--- a/climpred/tests/test_perfectModelEnsemble_class.py
+++ b/climpred/tests/test_perfectModelEnsemble_class.py
@@ -89,3 +89,56 @@ def test_inplace(PM_ds_initialized_1d, PM_ds_control_1d):
     pm.sum('init')
     summed = pm.sum('init')
     assert pm != summed
+
+
+def test_verify(perfectModelEnsemble_initialized_control):
+    """Test that verify works."""
+    assert perfectModelEnsemble_initialized_control.verify(
+        metric='mse', comparison='m2e'
+    )
+
+
+def test_warning_compute_metric(perfectModelEnsemble_initialized_control):
+    """Test that verify works."""
+    with pytest.warns(UserWarning) as record:
+        assert perfectModelEnsemble_initialized_control.compute_metric(
+            metric='mse', comparison='m2e'
+        )
+        if not record:
+            pytest.fail('Expected a warning.')
+
+
+def test_verify_metric_kwargs(perfectModelEnsemble_initialized_control):
+    """Test that verify with metric_kwargs works."""
+    pm = perfectModelEnsemble_initialized_control
+    pm = pm - pm.mean('time').mean('init')
+    assert pm.verify(metric='threshold_brier_score', comparison='m2c', threshold=0.5)
+
+
+def test_verify_fails_expected_metric_kwargs(perfectModelEnsemble_initialized_control):
+    """Test that verify without metric_kwargs fails."""
+    pm = perfectModelEnsemble_initialized_control
+    pm = pm - pm.mean('time').mean('init')
+    with pytest.raises(ValueError) as excinfo:
+        pm.verify(metric='threshold_brier_score', comparison='m2c')
+    assert 'Please provide threshold.' == str(excinfo.value)
+
+
+def test_compute_uninitialized_metric_kwargs(perfectModelEnsemble_initialized_control):
+    """Test that verify with metric_kwargs works."""
+    pm = perfectModelEnsemble_initialized_control
+    pm = pm - pm.mean('time').mean('init')
+    pm = pm.generate_uninitialized()
+    assert pm.compute_uninitialized(
+        metric='threshold_brier_score', comparison='m2c', threshold=0.5
+    )
+
+
+def test_bootstrap_metric_kwargs(perfectModelEnsemble_initialized_control):
+    """Test that bootstrap with metric_kwargs works."""
+    pm = perfectModelEnsemble_initialized_control
+    pm = pm - pm.mean('time').mean('init')
+    pm = pm.generate_uninitialized()
+    assert pm.bootstrap(
+        metric='threshold_brier_score', comparison='m2c', threshold=0.5, iterations=3
+    )

--- a/climpred/tests/test_perfectModelEnsemble_class.py
+++ b/climpred/tests/test_perfectModelEnsemble_class.py
@@ -99,7 +99,7 @@ def test_verify(perfectModelEnsemble_initialized_control):
 
 
 def test_warning_compute_metric(perfectModelEnsemble_initialized_control):
-    """Test that verify works."""
+    """Test that compute_metric throws warning."""
     with pytest.warns(UserWarning) as record:
         assert perfectModelEnsemble_initialized_control.compute_metric(
             metric='mse', comparison='m2e'
@@ -143,7 +143,7 @@ def test_verify_fails_expected_metric_kwargs(perfectModelEnsemble_initialized_co
 
 
 def test_compute_uninitialized_metric_kwargs(perfectModelEnsemble_initialized_control):
-    """Test that verify with metric_kwargs works."""
+    'Test that compute_uninitialized with metric_kwargs works'
     pm = perfectModelEnsemble_initialized_control
     pm = pm - pm.mean('time').mean('init')
     pm = pm.generate_uninitialized()

--- a/climpred/tests/test_perfectModelEnsemble_class.py
+++ b/climpred/tests/test_perfectModelEnsemble_class.py
@@ -115,6 +115,24 @@ def test_verify_metric_kwargs(perfectModelEnsemble_initialized_control):
     assert pm.verify(metric='threshold_brier_score', comparison='m2c', threshold=0.5)
 
 
+@pytest.mark.parametrize(
+    'reference',
+    ['historical', ['historical'], 'persistence', None, ['historical', 'persistence']],
+)
+def test_verify_reference(perfectModelEnsemble_initialized_control, reference):
+    """Test that verify works with references given."""
+    pm = perfectModelEnsemble_initialized_control.generate_uninitialized()
+    skill = pm.verify(metric='rmse', comparison='m2e', reference=reference)
+    if isinstance(reference, str):
+        reference = [reference]
+    elif reference is None:
+        reference = []
+    if len(reference) == 0:
+        assert 'skill' not in skill.dims
+    else:
+        assert skill.skill.size == len(reference) + 1
+
+
 def test_verify_fails_expected_metric_kwargs(perfectModelEnsemble_initialized_control):
     """Test that verify without metric_kwargs fails."""
     pm = perfectModelEnsemble_initialized_control


### PR DESCRIPTION
# Description

add metric_kwargs to PredictionEnsemble methods

Closes #386 

## Type of change

Please delete options that are not relevant.

-   [x]  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

pytest

## Checklist (while developing)

-   [x]  Tests added for `pytest`, if necessary.

## Pre-Merge Checklist (final steps)

-   [x]  I have rebased onto master or develop (wherever I am merging) and dealt with any conflicts.
-   [x]  I have squashed commits to a reasonable amount, and force-pushed the squashed commits.

