### PR TITLE
Add HackMD badge to docs and readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,9 @@ An xarray wrapper for analysis of ensemble forecast models for climate predictio
     :alt: license
     :target: LICENSE.txt
 
+.. image:: https://hackmd.io/pCuOUX-OTfChkfUl2qEi9g/badge
+    :target: https://hackmd.io/pCuOUX-OTfChkfUl2qEi9g
+
 Installation
 ============
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,9 @@ climpred: analysis of ensemble forecast models for climate prediction
     :alt: license
     :target: ../../LICENSE.txt
 
+.. image:: https://hackmd.io/pCuOUX-OTfChkfUl2qEi9g/badge
+    :target: https://hackmd.io/pCuOUX-OTfChkfUl2qEi9g
+
 Version 2.0.0 Release
 =====================
 


### PR DESCRIPTION
HackMD just added a badge, so you can link to a collaborative markdown note. I thought it'd be nice to have a badge to a note where we sketch out a continuously updated roadmap. This would sort of triage the issues and also sketch out long-term ideas and rank them in priority order.

Let me know what happens when you click the badge @aaronspring / @ahuang11 / @raybellwaves. I'm curious if anyone can just come in and overwrite/delete everything or if there's some level of accepting changes.