### PR TITLE
Fix black travis

### DIFF
--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -27,6 +27,7 @@ dependencies:
   - asv
   - black
   - coveralls
+  - dataclasses  # to get black to not error
   - doc8
   - flake8
   - importlib_metadata

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -25,7 +25,7 @@ dependencies:
   - xarray>=0.16.0
   # Package Management
   - asv
-  - black
+  - black==19.10b0
   - coveralls
   - dataclasses  # to get black to not error
   - doc8


### PR DESCRIPTION
# Description

`black` has been breaking on all of our Travis builds since they recently released a new version that relies upon `dataclasses`. Not sure why that didn't get installed with the recent update, but I just added it as a dev requirement.
